### PR TITLE
Add Digito Conta on CNAB generation

### DIFF
--- a/Boleto2.Net/Banco/BancoInter.cs
+++ b/Boleto2.Net/Banco/BancoInter.cs
@@ -264,7 +264,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 019, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0021, 003, 0, "112", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0024, 004, 0, "0001", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0028, 010, 0, boleto.Banco.Cedente.ContaBancaria.ContaFormatada(), '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0028, 010, 0, boleto.Banco.Cedente.ContaBancaria.ContaFormatada().PadLeft(10, '0'), '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0038, 025, 0, Empty, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0063, 003, 0, Empty, ' ');
                 //Valor da multa informado em percentual

--- a/Boleto2.Net/Banco/BancoInter.cs
+++ b/Boleto2.Net/Banco/BancoInter.cs
@@ -264,7 +264,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 019, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0021, 003, 0, "112", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0024, 004, 0, "0001", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0028, 010, 0, boleto.Banco.Cedente.ContaBancaria.Conta.PadLeft(10, '0'), '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0028, 010, 0, boleto.Banco.Cedente.ContaBancaria.ContaFormatada(), '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0038, 025, 0, Empty, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0063, 003, 0, Empty, ' ');
                 //Valor da multa informado em percentual

--- a/Boleto2.Net/Boleto/ContaBancaria.cs
+++ b/Boleto2.Net/Boleto/ContaBancaria.cs
@@ -37,5 +37,10 @@ namespace Boleto2Net
             var conta = Conta;
             Conta = conta.Length <= digitosConta ? conta.PadLeft(digitosConta, '0') : throw Boleto2NetException.ContaInvalida(conta, digitosConta);
         }
+
+        public string ContaFormatada()
+        {
+            return $"{Conta}{DigitoConta}".PadLeft(10, '0');
+        }
     }
 }

--- a/Boleto2.Net/Boleto/ContaBancaria.cs
+++ b/Boleto2.Net/Boleto/ContaBancaria.cs
@@ -18,7 +18,7 @@ namespace Boleto2Net
         public TipoFormaCadastramento TipoFormaCadastramento { get; set; } = TipoFormaCadastramento.ComRegistro;
         public TipoImpressaoBoleto TipoImpressaoBoleto { get; set; } = TipoImpressaoBoleto.Empresa;
         public TipoDocumento TipoDocumento { get; set; } = TipoDocumento.Tradicional;
-        public string LocalPagamento { get; set; } = "PAGÁVEL EM QUALQUER BANCO.";
+        public string LocalPagamento { get; set; } = "PAGï¿½VEL EM QUALQUER BANCO.";
         public string MensagemFixaTopoBoleto { get; set; } = "";
         public string MensagemFixaSacado { get; set; } = "";
         public int CodigoBancoCorrespondente { get; set; }
@@ -40,7 +40,7 @@ namespace Boleto2Net
 
         public string ContaFormatada()
         {
-            return $"{Conta}{DigitoConta}".PadLeft(10, '0');
+            return $"{Conta}{DigitoConta}";
         }
     }
 }

--- a/Boleto2.Net/Boleto/ContaBancaria.cs
+++ b/Boleto2.Net/Boleto/ContaBancaria.cs
@@ -18,7 +18,7 @@ namespace Boleto2Net
         public TipoFormaCadastramento TipoFormaCadastramento { get; set; } = TipoFormaCadastramento.ComRegistro;
         public TipoImpressaoBoleto TipoImpressaoBoleto { get; set; } = TipoImpressaoBoleto.Empresa;
         public TipoDocumento TipoDocumento { get; set; } = TipoDocumento.Tradicional;
-        public string LocalPagamento { get; set; } = "PAG�VEL EM QUALQUER BANCO.";
+        public string LocalPagamento { get; set; } = "PAGÁVEL EM QUALQUER BANCO.";
         public string MensagemFixaTopoBoleto { get; set; } = "";
         public string MensagemFixaSacado { get; set; } = "";
         public int CodigoBancoCorrespondente { get; set; }


### PR DESCRIPTION
O cliente teve problemas ao enviar o arquivo para geração de boleto e o Banco Inter informou a ele que o dígito da conta deve ser enviado junto com o numero.
Essa alteração adiciona o digito ao código já existente.