### PR TITLE
Fix/n3 2384/codigo convenio invalido

### DIFF
--- a/Boleto2.Net/Banco/BancoSicoob.cs
+++ b/Boleto2.Net/Banco/BancoSicoob.cs
@@ -59,7 +59,7 @@ namespace Boleto2Net
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
-        public string GerarHeaderRemessa(TipoArquivo tipoArquivo, int numeroArquivoRemessa, ref int numeroRegistroGeral)//AQUI
+        public string GerarHeaderRemessa(TipoArquivo tipoArquivo, int numeroArquivoRemessa, ref int numeroRegistroGeral)
         {
             try
             {

--- a/Boleto2.Net/Banco/BancoSicoob.cs
+++ b/Boleto2.Net/Banco/BancoSicoob.cs
@@ -59,7 +59,7 @@ namespace Boleto2Net
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
-        public string GerarHeaderRemessa(TipoArquivo tipoArquivo, int numeroArquivoRemessa, ref int numeroRegistroGeral)
+        public string GerarHeaderRemessa(TipoArquivo tipoArquivo, int numeroArquivoRemessa, ref int numeroRegistroGeral)//AQUI
         {
             try
             {
@@ -193,7 +193,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, Cedente.TipoCPFCNPJ("0"), '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 014, 0, Cedente.CPFCNPJ, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliDireita______, 0033, 020, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliDireita______, 0033, 020, 0, Cedente.Codigo, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0053, 005, 0, Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0058, 001, 0, Cedente.ContaBancaria.DigitoAgencia, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 012, 0, Cedente.ContaBancaria.Conta, '0');


### PR DESCRIPTION
## Tipo da Alteração

- [ ] Refatoração
- [ ] Nova Funcionalidade
- [X] Correção de Bug
- [ ] Documentação
- [ ] Configuração/Tarefa
- [ ] Outro:

## Descrição

- Adicionar código do Convenio na geração do Header da Remessa do Banco Sicoob

### Contexto
- Os arquivos de CNAB do Banco Sicoob deveriam ser gerados com o código do convenio, porém a equipe de CX está adicionando manualmente o código ao arquivo 

## Changelog

- Adiciona o `Cedente.Codigo` na Geração do Header na `GerarHeaderRemessaCNAB240`

## Como Testar

1. Gerar um novo pagamento passando via Plataforma o Código de convenio 925 e validar que o arquivo foi gerado com o código corretamente.

## Tarefas Relacionadas

- https://kamino.atlassian.net/browse/N3-2384

## Notas para o Revisor

- Verifique se o `Cedente.Codigo` é o código correto que representa o código do Convenio.

## Anexos

- Sem anexos