### PR TITLE
[N3-3384] - Corrige valor default para carteira CNAB remessa Itaú

### DIFF
--- a/Boleto2.Net/Banco/BancoItau.cs
+++ b/Boleto2.Net/Banco/BancoItau.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Web.UI;
 using Boleto2Net.Exceptions;
@@ -292,7 +292,7 @@ namespace Boleto2Net
                         break;
 
                     default:
-                        reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 108, 001, 0, "?", ' ');
+                        reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 108, 001, 0, "I", ' ');
                         break;
                 }
 


### PR DESCRIPTION
## Tipo da Alteração

- [x] Correção de Bug
- [ ] Refatoração
- [ ] Nova Funcionalidade
- [ ] Documentação
- [ ] Configuração/Tarefa
- [ ] Outro:

## Descrição

Correção do valor padrão utilizado para carteiras não mapeadas no processamento de CNAB remessa do Itaú. O valor "?" estava sendo utilizado como padrão, causando falha no processamento dos pagamentos.

### Contexto

No processamento de CNAB remessa do Itaú, quando a carteira do boleto não era "109" ou "112", o sistema estava definindo o valor "?" na posição 108 do registro. Este valor inválido estava impedindo que os pagamentos fossem processados corretamente pelo banco.

## Changelog

- Alterado valor padrão de "?" para "I" no switch da carteira CNAB remessa Itaú
- Padronizado comportamento para todas as carteiras utilizarem "I"

## Como Testar

- Gerar CNAB remessa para boletos Itaú com carteiras diferentes de "109" e "112"
- Verificar se o campo na posição 108 contém "I" ao invés de "?"
- Validar se o arquivo é aceito pelo banco sem erros

## Tarefas Relacionadas

- [Pagamento - CNAB remessa - Não efetuado - Itaú](https://kamino.atlassian.net/browse/N3-3384)

## Notas para o Revisor

- Alteração pontual no switch case do processamento de carteira
- Mudança crítica que resolve falha de pagamento
- Testar especialmente com carteiras não padrão (diferentes de 109/112)

## Anexos


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções de bugs**
  * Ajustada a geração de remessas CNAB400 para o Itaú, garantindo que o indicador de carteira padrão seja emitido corretamente, evitando caracteres inválidos e possíveis rejeições pelo banco. Alinha o comportamento às carteiras já suportadas.

* **Chores**
  * Limpeza de codificação no arquivo para remover marcador de byte-order, sem impacto funcional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->