### PR TITLE
[N3-3482] - Corrige geração de remessa CNAB240 do Banco do Brasil para garantir que os DVs de agência e conta nunca saiam em branco.

### DIFF
--- a/Boleto2.Net/Banco/BancoBrasil.cs
+++ b/Boleto2.Net/Banco/BancoBrasil.cs
@@ -475,9 +475,9 @@ namespace Boleto2Net
                 var _dvCc = OnlyDigits(Cedente.ContaBancaria.DigitoConta);
                 if (string.IsNullOrWhiteSpace(_dvCc)) _dvCc = "0";
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0053, 005, 0, _ag, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0058, 001, 0, _dvAg, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0058, 001, 0, _dvAg, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 012, 0, _cc, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0071, 001, 0, _dvCc, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0071, 001, 0, _dvCc, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0072, 001, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0073, 030, 0, Cedente.Nome, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0103, 030, 0, "BANCO DO BRASIL S.A.", ' ');
@@ -529,9 +529,9 @@ namespace Boleto2Net
                 var _dvCcL = OnlyDigits(Cedente.ContaBancaria.DigitoConta);
                 if (string.IsNullOrWhiteSpace(_dvCcL)) _dvCcL = "0";
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0054, 005, 0, _agL, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0059, 001, 0, _dvAgL, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 001, 0, _dvAgL, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0060, 012, 0, _ccL, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0072, 001, 0, _dvCcL, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0072, 001, 0, _dvCcL, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0073, 001, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0074, 030, 0, Cedente.Nome, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0104, 040, 0, string.Empty, ' ');
@@ -570,9 +570,9 @@ namespace Boleto2Net
                 var _dvCcP = OnlyDigits(boleto.Banco.Cedente.ContaBancaria.DigitoConta);
                 if (string.IsNullOrWhiteSpace(_dvCcP)) _dvCcP = "0";
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 005, 0, _agP, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0023, 001, 0, _dvAgP, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0023, 001, 0, _dvAgP, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0024, 012, 0, _ccP, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0036, 001, 0, _dvCcP, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0036, 001, 0, _dvCcP, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0037, 001, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0038, 020, 0, boleto.NossoNumero, ' ');
                 var tipoCarteira = (int)boleto.TipoCarteira;


### PR DESCRIPTION
## Tipo da Alteração
- [ ] Refatoração
- [ ] Nova Funcionalidade
- [x] Correção de Bug
- [ ] Documentação
- [ ] Configuração/Tarefa
- [ ] Outro:

## Descrição

### Contexto
A geração da remessa CNAB240 do Banco do Brasil apresentava DVs de agência/conta em branco no Header do Arquivo (pos. 58) e Header do Lote (pos. 59), causando reprovação no validador do BB. Foi ajustado para garantir campos numéricos e default "0" quando ausentes.

## Changelog
- [Boleto2Net/Boleto2.Net/Banco/BancoBrasil.cs](cci:7://file:///c:/Dev/Kamino/GitHub/Plataforma-Hub-API/Boleto2Net/Boleto2.Net/Banco/BancoBrasil.cs:0:0-0:0)
  - [GerarHeaderRemessaCNAB240](cci:1://file:///c:/Dev/Kamino/GitHub/Plataforma-Hub-API/Boleto2Net/Boleto2.Net/Banco/BancoBrasil.cs:453:8-501:9): DV agência (pos 58) e DV conta (pos 71) para `ediNumericoSemSeparador_` (filler '0').
  - [GerarHeaderLoteRemessaCNAB240](cci:1://file:///c:/Dev/Kamino/GitHub/Plataforma-Hub-API/Boleto2Net/Boleto2.Net/Banco/BancoBrasil.cs:503:8-550:9): DV agência (pos 59) e DV conta (pos 72) para `ediNumericoSemSeparador_` (filler '0').
  - [GerarDetalheSegmentoPRemessaCNAB240](cci:1://file:///c:/Dev/Kamino/GitHub/Plataforma-Hub-API/Boleto2Net/Boleto2.Net/Banco/BancoBrasil.cs:552:8-665:9): DV agência (pos 23) e DV conta (pos 36) para `ediNumericoSemSeparador_` (filler '0').
  - Preservado saneamento via [OnlyDigits(...)](cci:1://file:///c:/Dev/Kamino/GitHub/Plataforma-Hub-API/Boleto2Net/Boleto2.Net/Banco/BancoBrasil.cs:1095:8-1100:9) e default "0" quando vazio.

## Como Testar
- Configurar `Cedente.ContaBancaria` com agência/conta e DVs possivelmente vazios.
- Gerar remessa CNAB240.
- Validar no validador do Banco do Brasil:
  - Header do Arquivo: pos 58 e 71 não em branco.
  - Header do Lote: pos 59 e 72 não em branco.
  - Segmento P: pos 23 e 36 não em branco.
- Confirmar que DVs são numéricos e, se ausentes, vêm como "0".

## Tarefas Relacionadas
- [N3-3482 - CNAB - Arquivo de remessa - Banco do Brasil](https://kamino.atlassian.net/browse/N3-3482)

## Notas para o Revisor
- Mudanças localizadas no layout CNAB240 do BB.
- Impacto em outros bancos não esperado.
- Recomenda-se um teste com contas sem DV para confirmar default.

## Anexos

## Guias
[Guia para escrita de Pull Requests](https://www.notion.so/kaminoteam/Guia-para-Escrita-de-Pull-Requests-1365352e646e80cc99bee99712c67cc5)  
[Guia para escrita de comentários](https://www.notion.so/kaminoteam/Guia-para-escrita-de-Coment-rios-no-Pull-Request-1605352e646e80a0950bdc941013fb69)  
[Guia para revisão de código](https://www.notion.so/kaminoteam/Guia-para-Revis-o-de-C-digo-1365352e646e80b9a064e0dd3d519c0f)