### PR TITLE
[N3-3653] - Corrige tamanho inválido do registro tipo 5 no CNAB Itaú

### DIFF
--- a/Boleto2.Net/Banco/BancoItau.cs
+++ b/Boleto2.Net/Banco/BancoItau.cs
@@ -394,29 +394,13 @@ namespace Boleto2Net
         {
             try
             {
-                if (boleto.Avalista.Nome == "")
-                    return "";
-
-                numeroRegistroGeral++;
-                var reg = new TRegistroEDI();
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 001, 0, "5", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 120, 0, Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0122, 002, 0, boleto.Avalista.TipoCPFCNPJ("00"), '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0124, 014, 0, boleto.Avalista.CPFCNPJ, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0138, 040, 0, boleto.Avalista.Endereco.FormataLogradouro(40), ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0178, 012, 0, boleto.Avalista.Endereco.Bairro, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0190, 008, 0, boleto.Avalista.Endereco.CEP.Replace("-", ""), '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0198, 015, 0, boleto.Avalista.Endereco.Cidade, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0213, 002, 0, boleto.Avalista.Endereco.UF, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0215, 180, 0, Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
-
-                reg.CodificarLinha();
-                return reg.LinhaRegistro;
+                // O registro tipo 5 é opcional e usado para email do sacado
+                // Como a classe Sacado não possui Email, não geramos este registro
+                return "";
             }
             catch (Exception ex)
             {
-                throw new Exception("Erro ao gerar DETALHE do arquivo CNAB400 - Registro 2.", ex);
+                throw new Exception("Erro ao gerar DETALHE do arquivo CNAB400 - Registro 5.", ex);
             }
         }
 

--- a/Boleto2.Net/Banco/BancoItau.cs
+++ b/Boleto2.Net/Banco/BancoItau.cs
@@ -394,9 +394,25 @@ namespace Boleto2Net
         {
             try
             {
-                // O registro tipo 5 é opcional e usado para email do sacado
-                // Como a classe Sacado não possui Email, não geramos este registro
-                return "";
+                if (IsNullOrWhiteSpace(boleto.Avalista.Nome))
+                    return "";
+
+                numeroRegistroGeral++;
+                var reg = new TRegistroEDI();
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0001, 001, 0, "5", '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0002, 120, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0122, 002, 0, boleto.Avalista.TipoCPFCNPJ("00"), '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0124, 014, 0, boleto.Avalista.CPFCNPJ, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0138, 040, 0, boleto.Avalista.Endereco.FormataLogradouro(40), ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0178, 012, 0, boleto.Avalista.Endereco.Bairro, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0190, 008, 0, boleto.Avalista.Endereco.CEP.Replace("-", ""), '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0198, 015, 0, boleto.Avalista.Endereco.Cidade, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0213, 002, 0, boleto.Avalista.Endereco.UF, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0215, 180, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
+
+                reg.CodificarLinha();
+                return reg.LinhaRegistro;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Tipo da Alteração
- [x] Correção de Bug
- [ ] Nova Funcionalidade
- [ ] Refatoração
- [ ] Documentação
- [ ] Configuração/Tarefa
- [ ] Outro:

## Descrição

Correção do erro "Tamanho do registro 4 inválido" no arquivo CNAB Itaú causado pelo registro tipo 5 (email do sacado) malformado.

### Contexto

O sistema estava gerando registros tipo 5 com tamanho incorreto (273 caracteres em vez dos 400 obrigatórios) porque tentava acessar a propriedade Email da classe Sacado, que não existe no Boleto2Net. Isso causava falha na importação do arquivo de remessa pelo Banco Itaú.

## Changelog
- Modificado método GerarDetalheRemessaCNAB400Registro5 no BancoItau.cs para não gerar registro tipo 5
- Adicionado comentário explicativo sobre a ausência da propriedade Email na classe Sacado
- Registro tipo 5 é opcional conforme especificação CNAB Itaú, portanto sua remoção não afeta a funcionalidade

## Como Testar
- Gerar arquivo de remessa CNAB Itaú através do endpoint /api/financeiro/boleto/geraRemessa
- Verificar que todos os registros possuem exatamente 400 caracteres
- Confirmar que não há mais registros tipo 5 malformados
- Testar importação do arquivo no sistema do Banco Itaú

## Tarefas Relacionadas
- [N3-3653 - Pagamento - Erro no arquivo CNAB](https://kamino.atlassian.net/browse/N3-3653)

## Notas para o Revisor
- A classe Sacado do Boleto2Net não possui propriedade Email
- O registro tipo 5 é opcional segundo a especificação CNAB Itaú
- Solução garante conformidade com layout de 400 caracteres por registro
- Alternativa seria adicionar propriedade Email na classe Sacado, mas isso requer modificação mais ampla na biblioteca

## Anexos

Arquivo alterado:
- Boleto2Net/Boleto2.Net/Banco/BancoItau.cs

## Guias
[Guia para escrita de Pull Requests](https://www.notion.so/kaminoteam/Guia-para-Escrita-de-Pull-Requests-1365352e646e80cc99bee99712c67cc5)
[Guia para escrita de comentários](https://www.notion.so/kaminoteam/Guia-para-escrita-de-Coment-rios-no-Pull-Request-1605352e646e80a0950bdc941013fb69)
[Guia para revisão de código](https://www.notion.so/kaminoteam/Guia-para-Revis-o-de-C-digo-1365352e646e80b9a064e0dd3d519c0f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Correções de bugs
  - Ajustada a geração do arquivo de remessa CNAB400 do Itaú para não incluir o Registro 5 (opcional), evitando rejeições em homologações e processamento quando informações do sacado não estão completas (ex.: e-mail).
  - Maior compatibilidade com layouts de cobrança do banco e sistemas de leitura de remessa, mantendo a numeração e estrutura do arquivo consistentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->