### PR TITLE
[N3-4253] - Corrige limite de digitos da conta Caixa para geracao de boleto VAN

### DIFF
--- a/Boleto2.Net/Banco/BancoCaixa.cs
+++ b/Boleto2.Net/Banco/BancoCaixa.cs
@@ -30,7 +30,7 @@ namespace Boleto2Net
             if (!CarteiraFactory<BancoCaixa>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacaoPadrao))
                 throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacaoPadrao);
 
-            contaBancaria.FormatarDados("PREFERENCIALMENTE NAS CASAS LOTERICAS ATE O VALOR LIMITE", "", "SAC CAIXA: 0800 726 0101 (informações, reclamações, sugestões e elogios)<br>Para pessoas com deficiência auditiva ou de fala: 0800 726 2492<br>Ouvidoria: 0800 725 7474<br>caixa.gov.br<br>", 6);
+            contaBancaria.FormatarDados("PREFERENCIALMENTE NAS CASAS LOTERICAS ATE O VALOR LIMITE", "", "SAC CAIXA: 0800 726 0101 (informações, reclamações, sugestões e elogios)<br>Para pessoas com deficiência auditiva ou de fala: 0800 726 2492<br>Ouvidoria: 0800 725 7474<br>caixa.gov.br<br>", 11);
 
             var codigoCedente = Cedente.Codigo;
             Cedente.Codigo = codigoCedente.Length == 6 || codigoCedente.Length == 7 ? Cedente.Codigo : throw new ArgumentException($"O código do cedente ({codigoCedente}) deve conter 6 ou 7 dígitos."); //#329


### PR DESCRIPTION
## Tipo da Alteracao

- [ ] Refatoracao
- [ ] Nova Funcionalidade
- [x] Correcao de Bug
- [ ] Documentacao
- [ ] Configuracao/Tarefa
- [ ] Outro:

## Descricao

Aumenta o limite de digitos da conta bancaria (`digitosConta`) de 6 para 11 no `BancoCaixa.FormataCedente()`, permitindo que contas da Caixa com formato operacional (OOO+XXXXXXXX) gerem barcode e PDF corretamente.

### Contexto

O metodo `ContaBancaria.FormatarDados()` valida que o numero da conta nao exceda `digitosConta` digitos. Para a Caixa, esse limite estava em 6, porem contas reais da Caixa possuem ate 11 digitos (3 de operacao + 8 de conta). Isso causava a excecao `"O numero da conta (XXXXXXX) deve conter 6 digitos."` durante a geracao local de barcode/linha digitavel via Boleto2Net, apos o boleto ja ter sido registrado com sucesso na Theke/VAN.

**Exemplo do problema**: Ao gerar boleto VAN para conta Caixa `577835575-7` (9 digitos), a API registrava o boleto na Theke com sucesso, mas falhava na geracao do barcode local, resultando em boleto sem PDF e sem codigo de barras.

**Cliente afetado**: Polo Construcoes (poloconstrucoes.kamino.pro)

## Changelog

- `Boleto2.Net/Banco/BancoCaixa.cs:33` - Alterado `digitosConta` de 6 para 11 na chamada `FormatarDados()`

## Como Testar

1. Rodar os testes existentes `BancoCaixaCarteiraSig14Tests` — devem continuar passando (contas de 6 digitos nao sao afetadas funcionalmente)
2. Validar que instanciar `BancoCaixa` com `ContaBancaria.Conta = "577835575"` (9 digitos) nao lanca excecao ao chamar `FormataCedente()`
3. Confirmar que barcode e linha digitavel continuam identicos para contas existentes (o campo `Conta` nao e usado no calculo de barcode da Caixa — usa `Cedente.Codigo`)

## Tarefas Relacionadas

- [N3-4253](https://kamino.atlassian.net/browse/N3-4253)

[N3-4253]: https://kamino.atlassian.net/browse/N3-4253
