### PR TITLE
fix: preencher Convênio no Header de Lote CNAB240 Sicoob (N3-4985)

### DIFF
--- a/Boleto2.Net/Banco/BancoSicoob.cs
+++ b/Boleto2.Net/Banco/BancoSicoob.cs
@@ -234,7 +234,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0017, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 001, 0, Cedente.TipoCPFCNPJ("0"), '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 015, 0, Cedente.CPFCNPJ, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliDireita______, 0034, 020, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliDireita______, 0034, 020, 0, Cedente.Codigo, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0054, 005, 0, Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0059, 001, 0, Cedente.ContaBancaria.DigitoAgencia, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0060, 012, 0, Cedente.ContaBancaria.Conta, '0');


### PR DESCRIPTION
## Summary

- Corrige campo "Código do Convênio no Banco" no **Header de Lote** CNAB240 Sicoob (`BancoSicoob.cs:237`) que estava vazio (`Empty`), causando rejeição total do arquivo
- O fix N3-2384 (commit `669d521`) corrigiu apenas o Header de **Arquivo** (linha 196), mas o mesmo campo no Header de **Lote** (linha 237) permaneceu vazio
- Aplica `Cedente.Codigo` em ambos os headers, conforme especificação CNAB240 FEBRABAN

## Root Cause

```
Header de Arquivo (linha 196): Cedente.Codigo ✅ (corrigido pelo N3-2384)
Header de Lote   (linha 237): Empty          ❌ → Cedente.Codigo ✅ (este PR)
```

O Sicoob valida o campo Convênio em **ambos** os headers e rejeita o arquivo inteiro quando está em branco no Header de Lote.

## Impact

- **Afeta todos os clientes Sicoob** (banco 756), não apenas o reportado (WR Agropasto)
- Cooperativas com validação mais rígida rejeitam o arquivo; outras podem aceitar apesar do campo vazio

## Test plan

- [ ] Gerar arquivo de remessa CNAB240 para conta Sicoob e verificar que o campo posição 34-53 do Header de Lote contém o código do convênio (não mais espaços em branco)
- [ ] Verificar que o Header de Arquivo (posição 33-52) continua correto
- [ ] Testar com cliente WR Agropasto (alias `wragropasto`, conta Sicoob Frutas IDConta=10)
- [ ] Upload do arquivo .rem no portal Sicoob e confirmar que não é mais rejeitado

Refs: N3-4985, N3-4648, N3-2384

🤖 Generated with [Claude Code](https://claude.com/claude-code)