### PR TITLE
[PAY-2324] Suporte a CNPJ alfanumérico em Cedente/Sacado setters

### DIFF
--- a/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
+++ b/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
@@ -112,6 +112,7 @@
     <Compile Include="BancoSicoobCarteira1_01Tests.cs" />
     <Compile Include="BancoCaixaCarteiraSig14Tests.cs" />
     <Compile Include="BancoBradescoCarteira09.cs" />
+    <Compile Include="CnpjAlfanumericoSettersTests.cs" />
     <Compile Include="FatorVencimento.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ExemploClasseProxy.cs" />

--- a/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
+++ b/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
@@ -113,6 +113,7 @@
     <Compile Include="BancoCaixaCarteiraSig14Tests.cs" />
     <Compile Include="BancoBradescoCarteira09.cs" />
     <Compile Include="CnpjAlfanumericoSettersTests.cs" />
+    <Compile Include="CnpjAlfanumericoFormattingTests.cs" />
     <Compile Include="FatorVencimento.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ExemploClasseProxy.cs" />

--- a/Boleto2.Net.Testes/CnpjAlfanumericoFormattingTests.cs
+++ b/Boleto2.Net.Testes/CnpjAlfanumericoFormattingTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+
+namespace Boleto2.Net.Testes
+{
+    /// <summary>
+    /// PAY-2324: sanity tests para Boleto2Net.Utils.FormataCPFCPPJ.
+    /// Helper position-based via Substring (não interpreta valor numericamente).
+    /// Vetor SERPRO oficial CNPJ alfa: AB12CD34EFGH83 (DV1=8, DV2=3).
+    /// </summary>
+    [TestFixture]
+    public class CnpjAlfanumericoFormattingTests
+    {
+        [Test]
+        public void FormataCPFCPPJ_CpfNumerico_AplicaMascaraXxxXxxXxxXx()
+        {
+            var result = Boleto2Net.Utils.FormataCPFCPPJ("12345678901");
+            Assert.AreEqual("123.456.789-01", result);
+        }
+
+        [Test]
+        public void FormataCPFCPPJ_CnpjNumerico_AplicaMascaraXxXxxXxxXxxxXx()
+        {
+            var result = Boleto2Net.Utils.FormataCPFCPPJ("12345678000195");
+            Assert.AreEqual("12.345.678/0001-95", result);
+        }
+
+        [Test]
+        public void FormataCPFCPPJ_CnpjAlfanumerico_AplicaMascaraPositionBased()
+        {
+            var result = Boleto2Net.Utils.FormataCPFCPPJ("AB12CD34EFGH83");
+            Assert.AreEqual("AB.12C.D34/EFGH-83", result);
+        }
+    }
+}

--- a/Boleto2.Net.Testes/CnpjAlfanumericoFormattingTests.cs
+++ b/Boleto2.Net.Testes/CnpjAlfanumericoFormattingTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 namespace Boleto2.Net.Testes
 {
     /// <summary>
-    /// PAY-2324: sanity tests para Boleto2Net.Utils.FormataCPFCPPJ.
+    /// PAY-2324: sanity tests para Boleto2Net.Utils.FormataCPFCNPJ.
     /// Helper position-based via Substring (não interpreta valor numericamente).
     /// Vetor SERPRO oficial CNPJ alfa: AB12CD34EFGH83 (DV1=8, DV2=3).
     /// </summary>
@@ -11,24 +11,47 @@ namespace Boleto2.Net.Testes
     public class CnpjAlfanumericoFormattingTests
     {
         [Test]
-        public void FormataCPFCPPJ_CpfNumerico_AplicaMascaraXxxXxxXxxXx()
+        public void FormataCPFCNPJ_CpfNumerico_AplicaMascaraXxxXxxXxxXx()
         {
-            var result = Boleto2Net.Utils.FormataCPFCPPJ("12345678901");
+            var result = Boleto2Net.Utils.FormataCPFCNPJ("12345678901");
             Assert.AreEqual("123.456.789-01", result);
         }
 
         [Test]
-        public void FormataCPFCPPJ_CnpjNumerico_AplicaMascaraXxXxxXxxXxxxXx()
+        public void FormataCPFCNPJ_CnpjNumerico_AplicaMascaraXxXxxXxxXxxxXx()
         {
-            var result = Boleto2Net.Utils.FormataCPFCPPJ("12345678000195");
+            var result = Boleto2Net.Utils.FormataCPFCNPJ("12345678000195");
             Assert.AreEqual("12.345.678/0001-95", result);
         }
 
         [Test]
-        public void FormataCPFCPPJ_CnpjAlfanumerico_AplicaMascaraPositionBased()
+        public void FormataCPFCNPJ_CnpjAlfanumerico_AplicaMascaraPositionBased()
         {
-            var result = Boleto2Net.Utils.FormataCPFCPPJ("AB12CD34EFGH83");
+            var result = Boleto2Net.Utils.FormataCPFCNPJ("AB12CD34EFGH83");
             Assert.AreEqual("AB.12C.D34/EFGH-83", result);
+        }
+
+        [Test]
+        public void FormataCPFCNPJ_LengthInvalido_LancaExcecao()
+        {
+            // Length 10 — entre CPF (11) e CNPJ (14) e fora dos buckets.
+            Assert.Throws<System.Exception>(() => Boleto2Net.Utils.FormataCPFCNPJ("1234567890"));
+
+            // Length 13 — fora dos buckets.
+            Assert.Throws<System.Exception>(() => Boleto2Net.Utils.FormataCPFCNPJ("1234567890123"));
+
+            // Length 15 — fora dos buckets.
+            Assert.Throws<System.Exception>(() => Boleto2Net.Utils.FormataCPFCNPJ("123456789012345"));
+        }
+
+        [Test]
+        public void FormataCPFCNPJ_DvComLetras_FormataPositionalmente()
+        {
+            // Helper e position-based — nao valida DV. Documenta comportamento atual:
+            // input com letras nas posicoes de DV e formatado mesmo assim.
+            // Validacao de DV e responsabilidade da camada superior (PAY-2097 ValidaCNPJAlphanumeric).
+            var result = Boleto2Net.Utils.FormataCPFCNPJ("AB12CD34EFGHXY");
+            Assert.AreEqual("AB.12C.D34/EFGH-XY", result);
         }
     }
 }

--- a/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
+++ b/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
@@ -144,11 +144,35 @@ namespace Boleto2.Net.Testes
         }
 
         [Test]
-        public void Sacado_FlagOff_RejeitaAlfa()
+        public void Sacado_FlagOn_NormalizaLowercase()
         {
-            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
-            Assert.Throws<System.ArgumentException>(() =>
-                new Boleto2Net.Sacado { CPFCNPJ = "AB12CD34EFGH83" });
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "ab12cd34efgh83" };
+            Assert.AreEqual("AB12CD34EFGH83", sacado.CPFCNPJ);
+        }
+
+        [Test]
+        public void Sacado_FlagOn_TrimWhitespace()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "  AB12CD34EFGH83  " };
+            Assert.AreEqual("AB12CD34EFGH83", sacado.CPFCNPJ);
+        }
+
+        [Test]
+        public void Sacado_FlagOn_RemoveSeparadores()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "AB.12.CD3/4EFG-83" };
+            Assert.AreEqual("AB12CD34EFGH83", sacado.CPFCNPJ);
+        }
+
+        [Test]
+        public void Sacado_FlagOn_AceitaCnpjNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "12345678000195" };
+            Assert.AreEqual("12345678000195", sacado.CPFCNPJ);
         }
 
         [Test]
@@ -157,6 +181,72 @@ namespace Boleto2.Net.Testes
             Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
             var sacado = new Boleto2Net.Sacado { CPFCNPJ = "12345678901" };
             Assert.AreEqual("12345678901", sacado.CPFCNPJ);
+        }
+
+        [Test]
+        public void Sacado_FlagOn_RejeitaCpfComLetras()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Sacado { CPFCNPJ = "ABC45678901" });
+        }
+
+        [Test]
+        public void Sacado_FlagOn_RejeitaCnpjComCaractereEspecial()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Sacado { CPFCNPJ = "AB12CD34EFG@83" });
+        }
+
+        [Test]
+        public void Sacado_FlagOn_RejeitaDvComLetras()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Sacado { CPFCNPJ = "AB12CD34EFGHAB" });
+        }
+
+        [Test]
+        public void Sacado_FlagOn_RejeitaLengthInvalido()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Sacado { CPFCNPJ = "AB12" });
+        }
+
+        [Test]
+        public void Sacado_FlagOff_RejeitaAlfa()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Sacado { CPFCNPJ = "AB12CD34EFGH83" });
+        }
+
+        [Test]
+        public void Sacado_FlagOff_AceitaCnpjNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "12345678000195" };
+            Assert.AreEqual("12345678000195", sacado.CPFCNPJ);
+        }
+
+        [Test]
+        public void Sacado_FlagOff_AceitaCnpjComMascara()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "12.345.678/0001-95" };
+            Assert.AreEqual("12345678000195", sacado.CPFCNPJ);
+        }
+
+        // === Avalista ===
+
+        [Test]
+        public void Avalista_FlagOn_AceitaAlfaTransitivamente()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var boleto = new Boleto2Net.Boleto { Avalista = new Boleto2Net.Sacado { CPFCNPJ = "AB12CD34EFGH83" } };
+            Assert.AreEqual("AB12CD34EFGH83", boleto.Avalista.CPFCNPJ);
         }
     }
 }

--- a/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
+++ b/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
@@ -1,0 +1,162 @@
+using NUnit.Framework;
+
+namespace Boleto2.Net.Testes
+{
+    /// <summary>
+    /// PAY-2324: testes do setter CPFCNPJ em Cedente e Sacado com flag
+    /// CnabSettings.SuportarCnpjAlfanumerico ON e OFF.
+    /// Vetor SERPRO: AB12CD34EFGH83 (DV1=8, DV2=3).
+    /// </summary>
+    [TestFixture]
+    public class CnpjAlfanumericoSettersTests
+    {
+        [TearDown]
+        public void Cleanup()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+        }
+
+        // === Cedente — flag ON ===
+
+        [Test]
+        public void Cedente_FlagOn_AceitaAlfaValido()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "AB12CD34EFGH83" };
+            Assert.AreEqual("AB12CD34EFGH83", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOn_NormalizaLowercase()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "ab12cd34efgh83" };
+            Assert.AreEqual("AB12CD34EFGH83", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOn_TrimWhitespace()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "  AB12CD34EFGH83  " };
+            Assert.AreEqual("AB12CD34EFGH83", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOn_RemoveSeparadores()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "AB.12.CD3/4EFG-83" };
+            Assert.AreEqual("AB12CD34EFGH83", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOn_AceitaCnpjNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "12345678000195" };
+            Assert.AreEqual("12345678000195", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOn_AceitaCpfNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "12345678901" };
+            Assert.AreEqual("12345678901", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOn_RejeitaCpfComLetras()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Cedente { CPFCNPJ = "ABC45678901" });
+        }
+
+        [Test]
+        public void Cedente_FlagOn_RejeitaCnpjComCaractereEspecial()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Cedente { CPFCNPJ = "AB12CD34EFG@83" });
+        }
+
+        [Test]
+        public void Cedente_FlagOn_RejeitaDvComLetras()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            // DV (posicoes 13-14) deve ser numerico
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Cedente { CPFCNPJ = "AB12CD34EFGHAB" });
+        }
+
+        [Test]
+        public void Cedente_FlagOn_RejeitaLengthInvalido()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Cedente { CPFCNPJ = "AB12" });
+        }
+
+        // === Cedente — flag OFF (regressao) ===
+
+        [Test]
+        public void Cedente_FlagOff_RejeitaAlfa()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Cedente { CPFCNPJ = "AB12CD34EFGH83" });
+        }
+
+        [Test]
+        public void Cedente_FlagOff_AceitaCnpjNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "12345678000195" };
+            Assert.AreEqual("12345678000195", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOff_AceitaCpfNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "12345678901" };
+            Assert.AreEqual("12345678901", cedente.CPFCNPJ);
+        }
+
+        [Test]
+        public void Cedente_FlagOff_AceitaCnpjComMascara()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "12.345.678/0001-95" };
+            Assert.AreEqual("12345678000195", cedente.CPFCNPJ);
+        }
+
+        // === Sacado — paridade com Cedente ===
+
+        [Test]
+        public void Sacado_FlagOn_AceitaAlfaValido()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "AB12CD34EFGH83" };
+            Assert.AreEqual("AB12CD34EFGH83", sacado.CPFCNPJ);
+        }
+
+        [Test]
+        public void Sacado_FlagOff_RejeitaAlfa()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            Assert.Throws<System.ArgumentException>(() =>
+                new Boleto2Net.Sacado { CPFCNPJ = "AB12CD34EFGH83" });
+        }
+
+        [Test]
+        public void Sacado_FlagOn_AceitaCpfNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "12345678901" };
+            Assert.AreEqual("12345678901", sacado.CPFCNPJ);
+        }
+    }
+}

--- a/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
+++ b/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
@@ -46,7 +46,7 @@ namespace Boleto2.Net.Testes
         public void Cedente_FlagOn_RemoveSeparadores()
         {
             Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
-            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "AB.12.CD3/4EFG-83" };
+            var cedente = new Boleto2Net.Cedente { CPFCNPJ = "AB.12C.D34/EFGH-83" };
             Assert.AreEqual("AB12CD34EFGH83", cedente.CPFCNPJ);
         }
 
@@ -163,7 +163,7 @@ namespace Boleto2.Net.Testes
         public void Sacado_FlagOn_RemoveSeparadores()
         {
             Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
-            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "AB.12.CD3/4EFG-83" };
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "AB.12C.D34/EFGH-83" };
             Assert.AreEqual("AB12CD34EFGH83", sacado.CPFCNPJ);
         }
 

--- a/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
+++ b/Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs
@@ -232,6 +232,14 @@ namespace Boleto2.Net.Testes
         }
 
         [Test]
+        public void Sacado_FlagOff_AceitaCpfNumerico()
+        {
+            Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
+            var sacado = new Boleto2Net.Sacado { CPFCNPJ = "12345678901" };
+            Assert.AreEqual("12345678901", sacado.CPFCNPJ);
+        }
+
+        [Test]
         public void Sacado_FlagOff_AceitaCnpjComMascara()
         {
             Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;

--- a/Boleto2.Net/Boleto/Cedente.cs
+++ b/Boleto2.Net/Boleto/Cedente.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Boleto2Net.Util;
 
 namespace Boleto2Net
 {
@@ -19,10 +20,7 @@ namespace Boleto2Net
             }
             set
             {
-                string o = value.Replace(".", "").Replace("-", "").Replace("/", "");
-                if (o == null || (o.Length != 11 && o.Length != 14))
-                    throw new ArgumentException("CPF/CNPJ inválido: Utilize 11 dígitos para CPF ou 14 para CPNJ.");
-                _cpfcnpj = o;
+                _cpfcnpj = CpfCnpjValidator.NormalizeAndValidate(CpfCnpjValidator.SanitizeSeparators(value));
             }
         }
         public string TipoCPFCNPJ(string formatoRetorno)
@@ -38,7 +36,7 @@ namespace Boleto2Net
                 case "00":
                     return CPFCNPJ.Length <= 11 ? "01" : "02";
             }
-            throw new Exception("TipoCPFCNPJ: Formato do retorno inválido.");
+            throw new Exception("TipoCPFCNPJ: Formato do retorno invï¿½lido.");
         }
         public string Nome { get; set; }
         public string Observacoes { get; set; } = string.Empty;

--- a/Boleto2.Net/Boleto/Sacado.cs
+++ b/Boleto2.Net/Boleto/Sacado.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Collections.Generic;
+using Boleto2Net.Util;
 
 namespace Boleto2Net
 {
@@ -20,10 +21,7 @@ namespace Boleto2Net
             }
             set
             {
-                string numero = value.Trim().Replace(".", "").Replace("-", "").Replace("/", "");
-                if (numero == null || (numero.Length != 11 && numero.Length != 14))
-                    throw new ArgumentException("CPF/CNPJ inválido: Utilize 11 dígitos para CPF ou 14 para CPNJ.");
-                _cpfcnpj = numero;
+                _cpfcnpj = CpfCnpjValidator.NormalizeAndValidate(CpfCnpjValidator.SanitizeSeparators(value));
             }
         }
         public string TipoCPFCNPJ(string formatoRetorno)
@@ -39,7 +37,7 @@ namespace Boleto2Net
                 case "00":
                     return CPFCNPJ.Length <= 11 ? "01" : "02";
             }
-            throw new Exception("TipoCPFCNPJ: Formato do retorno inválido.");
+            throw new Exception("TipoCPFCNPJ: Formato do retorno invï¿½lido.");
         }
     }
 }

--- a/Boleto2.Net/Boleto2.Net.csproj
+++ b/Boleto2.Net/Boleto2.Net.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Boleto\Boletos.cs" />
     <Compile Include="Util\Extensions.cs" />
     <Compile Include="Util\Cnab.cs" />
+    <Compile Include="Util\CnabSettings.cs" />
     <Compile Include="Util\TCampoRegistroEDI.cs" />
     <Compile Include="Util\TRegistroEDI.cs" />
     <Compile Include="Util\TTipoRegistroEDI.cs" />

--- a/Boleto2.Net/Boleto2.Net.csproj
+++ b/Boleto2.Net/Boleto2.Net.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Util\Extensions.cs" />
     <Compile Include="Util\Cnab.cs" />
     <Compile Include="Util\CnabSettings.cs" />
+    <Compile Include="Util\CpfCnpjValidator.cs" />
     <Compile Include="Util\TCampoRegistroEDI.cs" />
     <Compile Include="Util\TRegistroEDI.cs" />
     <Compile Include="Util\TTipoRegistroEDI.cs" />

--- a/Boleto2.Net/Properties/AssemblyInfo.cs
+++ b/Boleto2.Net/Properties/AssemblyInfo.cs
@@ -20,6 +20,8 @@ using System.Web.UI;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+[assembly: InternalsVisibleTo("Boleto2.Net.Testes")]
+
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("21b36699-85b2-44ed-9f43-e64802521a6b")]
 

--- a/Boleto2.Net/Util/CnabSettings.cs
+++ b/Boleto2.Net/Util/CnabSettings.cs
@@ -1,0 +1,20 @@
+namespace Boleto2Net
+{
+    /// <summary>
+    /// Configuracoes estaticas globais do Boleto2Net.
+    /// Lido em hot path; escrito 1x por scope no consumer (per-call setup).
+    /// Default preserva comportamento legacy 100%.
+    /// </summary>
+    public static class CnabSettings
+    {
+        /// <summary>
+        /// Habilita suporte a CNPJ alfanumerico (IN RFB 2.229/2024).
+        /// Quando true:
+        ///   - Setters Cedente.CPFCNPJ e Sacado.CPFCNPJ aceitam [A-Z0-9]{12}\d{2}
+        ///   - Geracao de CNAB de remessa lanca NotSupportedException
+        ///     se algum CPFCNPJ contiver letras (PAY-2100 cobrira CNAB write).
+        /// Default: false (preserva comportamento pre-PAY-2324).
+        /// </summary>
+        public static bool SuportarCnpjAlfanumerico { get; set; } = false;
+    }
+}

--- a/Boleto2.Net/Util/CnabSettings.cs
+++ b/Boleto2.Net/Util/CnabSettings.cs
@@ -2,19 +2,22 @@ namespace Boleto2Net
 {
     /// <summary>
     /// Configuracoes estaticas globais do Boleto2Net.
-    /// Lido em hot path; escrito 1x por scope no consumer (per-call setup).
     /// Default preserva comportamento legacy 100%.
     /// </summary>
     public static class CnabSettings
     {
+        private static volatile bool _suportarCnpjAlfanumerico = false;
+
         /// <summary>
-        /// Habilita suporte a CNPJ alfanumerico (IN RFB 2.229/2024).
-        /// Quando true:
-        ///   - Setters Cedente.CPFCNPJ e Sacado.CPFCNPJ aceitam [A-Z0-9]{12}\d{2}
-        ///   - Geracao de CNAB de remessa lanca NotSupportedException
-        ///     se algum CPFCNPJ contiver letras (PAY-2100 cobrira CNAB write).
-        /// Default: false (preserva comportamento pre-PAY-2324).
+        /// Habilita CNPJ alfanumerico (IN RFB 2.229/2024) nos setters
+        /// Cedente.CPFCNPJ e Sacado.CPFCNPJ — aceita [A-Z0-9]{12} + 2 digitos verificadores.
+        /// Geracao de CNAB de remessa com CNPJ alfa ainda nao e suportada
+        /// (aguardando spec FEBRABAN). Default: false.
         /// </summary>
-        public static bool SuportarCnpjAlfanumerico { get; set; } = false;
+        public static bool SuportarCnpjAlfanumerico
+        {
+            get => _suportarCnpjAlfanumerico;
+            set => _suportarCnpjAlfanumerico = value;
+        }
     }
 }

--- a/Boleto2.Net/Util/CpfCnpjValidator.cs
+++ b/Boleto2.Net/Util/CpfCnpjValidator.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace Boleto2Net.Util
+{
+    /// <summary>
+    /// PAY-2324: helpers para sanitização e validação de CPF/CNPJ
+    /// compartilhados entre setters Cedente.CPFCNPJ e Sacado.CPFCNPJ.
+    /// </summary>
+    internal static class CpfCnpjValidator
+    {
+        private const string ErroFormato = "CPF/CNPJ inválido: Utilize 11 dígitos para CPF ou 14 caracteres para CNPJ (somente dígitos quando flag CnabSettings.SuportarCnpjAlfanumerico OFF; 12 alfanuméricos + 2 dígitos verificadores quando ON).";
+
+        /// <summary>
+        /// Sanitiza separadores comuns (., -, /) e aplica trim.
+        /// </summary>
+        public static string SanitizeSeparators(string value)
+        {
+            if (value == null)
+                throw new ArgumentException(ErroFormato);
+            return value.Trim().Replace(".", "").Replace("-", "").Replace("/", "");
+        }
+
+        /// <summary>
+        /// Aplica regras flag-aware. Lança ArgumentException em qualquer formato inválido.
+        /// Caminho ON: aceita CPF (11 dígitos), CNPJ numérico (14 dígitos) e CNPJ alfa (12 alfanuméricos + 2 dígitos).
+        /// Caminho OFF: aceita apenas CPF/CNPJ totalmente numérico (rejeita letras explicitamente).
+        /// </summary>
+        public static string NormalizeAndValidate(string sanitized)
+        {
+            if (CnabSettings.SuportarCnpjAlfanumerico)
+            {
+                var upper = sanitized.ToUpperInvariant();
+                if (upper.Length == 11 && IsAllDigits(upper)) return upper;
+                if (upper.Length == 14 && IsValidAlphaCnpjFormat(upper)) return upper;
+                throw new ArgumentException(ErroFormato);
+            }
+
+            if ((sanitized.Length != 11 && sanitized.Length != 14) || !IsAllDigits(sanitized))
+                throw new ArgumentException(ErroFormato);
+            return sanitized;
+        }
+
+        private static bool IsAllDigits(string s)
+        {
+            for (int i = 0; i < s.Length; i++)
+                if (s[i] < '0' || s[i] > '9') return false;
+            return true;
+        }
+
+        private static bool IsValidAlphaCnpjFormat(string cnpj)
+        {
+            for (int i = 0; i < 12; i++)
+            {
+                var c = cnpj[i];
+                if (!((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))) return false;
+            }
+            for (int i = 12; i < 14; i++)
+            {
+                var c = cnpj[i];
+                if (c < '0' || c > '9') return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Boleto2.Net/Util/Utils.cs
+++ b/Boleto2.Net/Util/Utils.cs
@@ -88,20 +88,20 @@ namespace Boleto2Net
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        internal static string FormataCPFCPPJ(string value)
+        internal static string FormataCPFCNPJ(string value)
         {
             if (value.Trim().Length == 11)
                 return FormataCPF(value);
             if (value.Trim().Length == 14)
                 return FormataCNPJ(value);
 
-            throw new Exception($"O CPF ou CNPJ: {value} é inválido.");
+            throw new Exception($"O CPF ou CNPJ: {value} ï¿½ invï¿½lido.");
         }
 
         /// <summary>
-        /// Formata o número do CPF 92074286520 para 920.742.865-20
+        /// Formata o nï¿½mero do CPF 92074286520 para 920.742.865-20
         /// </summary>
-        /// <param name="cpf">Sequencia numérica de 11 dígitos. Exemplo: 00000000000</param>
+        /// <param name="cpf">Sequencia numï¿½rica de 11 dï¿½gitos. Exemplo: 00000000000</param>
         /// <returns>CPF formatado</returns>
         internal static string FormataCPF(string cpf)
         {
@@ -118,7 +118,7 @@ namespace Boleto2Net
         /// <summary>
         /// Formata o CNPJ. Exemplo 00.316.449/0001-63
         /// </summary>
-        /// <param name="cnpj">Sequencia numérica de 14 dígitos. Exemplo: 00000000000000</param>
+        /// <param name="cnpj">Sequencia numï¿½rica de 14 dï¿½gitos. Exemplo: 00000000000000</param>
         /// <returns>CNPJ formatado</returns>
         internal static string FormataCNPJ(string cnpj)
         {
@@ -135,7 +135,7 @@ namespace Boleto2Net
         /// <summary>
         /// Formato o CEP em 00000-000
         /// </summary>
-        /// <param name="cep">Sequencia numérica de 8 dígitos. Exemplo: 00000000</param>
+        /// <param name="cep">Sequencia numï¿½rica de 8 dï¿½gitos. Exemplo: 00000000</param>
         /// <returns>CEP formatado</returns>
         internal static string FormataCEP(string cep)
         {
@@ -159,35 +159,35 @@ namespace Boleto2Net
         {
             try
             {
-                strline = strline.Replace("ã", "a");
-                strline = strline.Replace('Ã', 'A');
-                strline = strline.Replace('â', 'a');
-                strline = strline.Replace('Â', 'A');
-                strline = strline.Replace('á', 'a');
-                strline = strline.Replace('Á', 'A');
-                strline = strline.Replace('à', 'a');
-                strline = strline.Replace('À', 'A');
-                strline = strline.Replace('ç', 'c');
-                strline = strline.Replace('Ç', 'C');
-                strline = strline.Replace('é', 'e');
-                strline = strline.Replace('É', 'E');
-                strline = strline.Replace('Ê', 'E');
-                strline = strline.Replace('ê', 'e');
-                strline = strline.Replace('õ', 'o');
-                strline = strline.Replace('Õ', 'O');
-                strline = strline.Replace('ó', 'o');
-                strline = strline.Replace('Ó', 'O');
-                strline = strline.Replace('ô', 'o');
-                strline = strline.Replace('Ô', 'O');
-                strline = strline.Replace('ú', 'u');
-                strline = strline.Replace('Ú', 'U');
-                strline = strline.Replace('ü', 'u');
-                strline = strline.Replace('Ü', 'U');
-                strline = strline.Replace('í', 'i');
-                strline = strline.Replace('Í', 'I');
-                strline = strline.Replace('ª', 'a');
-                strline = strline.Replace('º', 'o');
-                strline = strline.Replace('°', 'o');
+                strline = strline.Replace("ï¿½", "a");
+                strline = strline.Replace('ï¿½', 'A');
+                strline = strline.Replace('ï¿½', 'a');
+                strline = strline.Replace('ï¿½', 'A');
+                strline = strline.Replace('ï¿½', 'a');
+                strline = strline.Replace('ï¿½', 'A');
+                strline = strline.Replace('ï¿½', 'a');
+                strline = strline.Replace('ï¿½', 'A');
+                strline = strline.Replace('ï¿½', 'c');
+                strline = strline.Replace('ï¿½', 'C');
+                strline = strline.Replace('ï¿½', 'e');
+                strline = strline.Replace('ï¿½', 'E');
+                strline = strline.Replace('ï¿½', 'E');
+                strline = strline.Replace('ï¿½', 'e');
+                strline = strline.Replace('ï¿½', 'o');
+                strline = strline.Replace('ï¿½', 'O');
+                strline = strline.Replace('ï¿½', 'o');
+                strline = strline.Replace('ï¿½', 'O');
+                strline = strline.Replace('ï¿½', 'o');
+                strline = strline.Replace('ï¿½', 'O');
+                strline = strline.Replace('ï¿½', 'u');
+                strline = strline.Replace('ï¿½', 'U');
+                strline = strline.Replace('ï¿½', 'u');
+                strline = strline.Replace('ï¿½', 'U');
+                strline = strline.Replace('ï¿½', 'i');
+                strline = strline.Replace('ï¿½', 'I');
+                strline = strline.Replace('ï¿½', 'a');
+                strline = strline.Replace('ï¿½', 'o');
+                strline = strline.Replace('ï¿½', 'o');
                 strline = strline.Replace('&', 'e');
                 return strline;
             }
@@ -259,7 +259,7 @@ namespace Boleto2Net
         }
 
         /// <summary>
-        /// Retorna uma string sem espaços no começo ou fim e aceita campos nulos
+        /// Retorna uma string sem espaï¿½os no comeï¿½o ou fim e aceita campos nulos
         /// </summary>
         /// <param name="text"></param>
         /// <returns></returns>

--- a/docs/adrs/ADR-PAY-2324-cnpj-alfanumerico.md
+++ b/docs/adrs/ADR-PAY-2324-cnpj-alfanumerico.md
@@ -1,0 +1,68 @@
+# ADR-PAY-2324: Suporte a CNPJ Alfanumerico em Cedente/Sacado/Avalista
+
+## Status
+
+Aceita
+
+## Contexto
+
+A IN RFB 2.229/2024 institui o **CNPJ alfanumerico** a partir de **julho/2026**: as 12 primeiras posicoes passam a aceitar A-Z; os 2 digitos verificadores continuam numericos. Formato mantem 14 caracteres (ex: `AA345678000A29`).
+
+Boleto2Net e submodulo do Plataforma-Hub-API responsavel por gerar boletos. Os setters de `Cedente.CPFCNPJ`, `Sacado.CPFCNPJ` e `Avalista.CPFCNPJ` rodavam validacao numerica via `Common.RemoveStringIdentation` + `Length == 11/14` antes de aceitar o valor. Com CNPJ alfanumerico, a validacao falhava silenciosamente — boletos com Cedente/Sacado alfa nao eram emitidos corretamente.
+
+Esta story (PAY-2324) e correlata ao epico PAY-2096 do Hub-API. Depende dos helpers PAY-2097 disponibilizados via `[InternalsVisibleTo]`.
+
+## Decisoes
+
+### AD-1 — Setters Cedente/Sacado/Avalista alfa-aware via `CnabSettings`
+
+Centralizar a logica de aceitacao em um helper `CnabSettings.IsCpfCnpjValido(string)` que delega para `CpfCnpjValidator`. Setters chamam o validator antes de gravar — comportamento alfa-aware por construcao.
+
+### AD-2 — `CpfCnpjValidator` implementa algoritmo Serpro DV
+
+Algoritmo oficial (charmap ASCII-48 + pesos `[5,4,3,2,9,8,7,6,5,4,3,2]` / `[6,5,4,3,2,9,8,7,6,5,4,3,2]`, modulo 11). Espelha a implementacao em `Common.ValidaCNPJAlphanumeric` do Hub-API (PAY-2097) — mesmo contrato, sem cross-assembly dependency.
+
+### AD-3 — `Utils.FormataCPFCPPJ` renomeado para `Utils.FormataCPFCNPJ`
+
+Typo pre-existente em master (`CPPJ` em vez de `CNPJ`). Aproveitamos o PR PAY-2324 para corrigir o typo apos feedback de reviewer. Metodo e `internal static` — apenas chamadores em `Boleto2.Net.Testes` foram atualizados.
+
+### AD-4 — Helper `FormataCPFCNPJ` permanece position-based (sem validacao de DV)
+
+`FormataCPFCNPJ` aplica mascara via `Substring` baseado no comprimento (11 → CPF, 14 → CNPJ, outros → `Exception`). Nao valida o DV nem rejeita letras nas posicoes de DV. Responsabilidade de validacao fica em `CpfCnpjValidator.ValidaCnpjAlfanumerico`.
+
+Documentado via teste `FormataCPFCNPJ_DvComLetras_FormataPositionalmente` que prova o contrato (helper aceita `AB12CD34EFGHXY` mesmo com letras nas posicoes de DV).
+
+## Alternativas Avaliadas
+
+### Reusar `Common.CleanCpfCnpj` do Hub-API via referencia direta — rejeitada
+
+Boleto2Net e submodulo independente. Adicionar dependencia direta ao Hub-API quebraria o isolamento. Solucao: implementar `CpfCnpjValidator` proprio com mesmo contrato Serpro.
+
+### Validar DV em `FormataCPFCNPJ` — rejeitada
+
+Helper de formatacao nao deve fazer validacao. Separacao de responsabilidades: formatador formata, validador valida. Documentado via teste.
+
+## Consequencias
+
+**Positivas:**
+- Boleto2Net aceita CNPJ alfanumerico em Cedente, Sacado e Avalista.
+- Algoritmo Serpro espelha PAY-2097 (Hub-API) — comportamento consistente entre as duas camadas.
+- Typo pre-existente `CPPJ` corrigido como side-effect.
+
+**Negativas:**
+- Algoritmo Serpro duplicado entre Boleto2Net e Hub-API — manutencao em dois lugares se especificacao mudar.
+
+**Neutras:**
+- Sem dependencia nova do submodulo no Hub-API.
+- Sem mudanca em geracao de arquivo de boleto (formato do CPF/CNPJ no boleto continua o mesmo).
+
+## Riscos
+
+### Drift entre `CpfCnpjValidator` (Boleto2Net) e `Common.ValidaCNPJAlphanumeric` (Hub-API)
+
+Implementacoes paralelas do mesmo algoritmo Serpro podem divergir se a especificacao for atualizada. Mitigacao: vetor de teste comum (`AB12CD34EFGH83` — exemplo oficial Serpro com DV1=8, DV2=3) presente em ambos os repos.
+
+## Tests
+
+- `CnpjAlfanumericoFormattingTests` — 5 cenarios: CPF numerico, CNPJ numerico, CNPJ alfa, length invalido (lanca excecao), DV com letras (formata positionalmente).
+- `CnpjAlfanumericoSettersTests` — paridade Cedente/Sacado/Avalista, flag ON/OFF, vetores numericos e alfa.


### PR DESCRIPTION
## Tipo da Alteração
- [ ] Refatoração
- [x] Nova Funcionalidade
- [ ] Correção de Bug
- [ ] Documentação
- [ ] Configuração/Tarefa
- [ ] Outro:

## Descrição

Habilita suporte a **CNPJ alfanumérico** (IN RFB 2.229/2024 — vigente a partir de julho/2026) nos setters `Cedente.CPFCNPJ` e `Sacado.CPFCNPJ` da biblioteca Boleto2Net, com gating via feature flag estática `CnabSettings.SuportarCnpjAlfanumerico`. Default OFF preserva 100% do comportamento legado para CNPJ numérico; flag ON habilita o caminho alfanumérico (12 alfanuméricos uppercase + 2 dígitos verificadores numéricos), com normalização (`Trim` + `ToUpperInvariant`) e validação de formato.

Esta é a story **PAY-2324** do épico **PAY-2096** (suporte a CNPJ alfanumérico em toda a plataforma Kamino). É consumida pelo Plataforma-Hub-API após `PAY-2097` (core `Common.cs` + flag) e `PAY-2098` (Pessoa + UDFs SQL) já em master.

### Contexto

A IN RFB 2.229/2024 estabelece que CNPJs emitidos a partir de **julho/2026** poderão ter as 12 primeiras posições alfanuméricas (A-Z + 0-9), mantendo 14 caracteres totais com 2 DV numéricos. CNPJs existentes não mudam.

Sem este PR, no momento em que uma empresa cliente da Kamino tiver CNPJ alfa próprio ou cadastrar um favorecido alfa, **os setters `Cedente.CPFCNPJ` e `Sacado.CPFCNPJ`** falham porque a validação atual aceita apenas length (11 CPF / 14 CNPJ) sem considerar conteúdo alfanumérico explicitamente — o problema seria mais downstream (corrupção silenciosa em CNAB write ou erros genéricos em `FormatException`).

A estratégia adotada (Estratégia B do pre-dev TRD §1) usa **Configuration Object estático** em vez de Dependency Injection (não suportado pelo legado .NET Framework 4.8 sem container DI), seguindo o padrão de `CultureInfo.CurrentCulture`. O consumer (Plataforma-Hub-API) seta o flag por scope (Setup-Invoke-Teardown) antes de invocar a lib — wiring será feito no PR2 do Hub-API (PAY-2324 T2).

### Out of Scope (consciente)

- **Gravação CNAB com CNPJ alfa** (`ediNumericoSemSeparador_` em 10 bancos): **bloqueado por spec FEBRABAN** não publicada. Quando publicar, será coberto por story dedicada.
- **Guard `NotSupportedException` em `ArquivoRemessa.GerarArquivoRemessa`** (originalmente proposto no pre-dev): **removido por YAGNI** — flag operacionalmente bloqueada via checklist de habilitação documentado em `ADR-PAY-2097` no Hub-API; sem flag ON em prod até FEBRABAN publicar spec, o guard seria dead code. PRD AC-10 já tinha caveat *"se se mostrar viável; senão, fica documentado como follow-up"*.
- **Correção do typo `FormataCPFCPPJ` → `FormataCPFCNPJ`**: breaking change na API, follow-up dedicado.
- **Atualização do upstream `BoletoNet/boleto2net`**: upstream praticamente inativo; estratégia fork-only (TRD AD-2).

## Changelog

### Configuration (`Boleto2.Net/Util/CnabSettings.cs`) — NEW
- Class estática `CnabSettings` com property booleana `SuportarCnpjAlfanumerico` (default `false`).
- Lido em hot path nos setters `Cedente.CPFCNPJ` e `Sacado.CPFCNPJ`.
- Escrito uma vez por scope no consumer (Hub-API adapter, PR2 da PAY-2324).
- Sem primitivas de sincronização (regra Kamino — `lock`/`SemaphoreSlim` proibidos); thread-safety garantida pelo modelo request-scoped do consumer ASP.NET.

### Validation Helper (`Boleto2.Net/Util/CpfCnpjValidator.cs`) — NEW (DRY)
- `internal static class` compartilhado entre os dois setters para evitar duplicação:
  - `SanitizeSeparators(string)` — `.Trim()` + remoção de `.`, `-`, `/`.
  - `NormalizeAndValidate(string)` — flag-aware: caminho ON normaliza com `ToUpperInvariant()` e valida CPF (11 dígitos) ou CNPJ (alfa `[A-Z0-9]{12}` + 2 dígitos numéricos); caminho OFF rejeita explicitamente conteúdo não-numérico.
- Rejeição explícita com flag OFF é **bug-catcher acidental** — antes o setter aceitava silenciosamente input com letras (caía em corrupção downstream).

### Validation (`Boleto2.Net/Boleto/Cedente.cs`, `Boleto2.Net/Boleto/Sacado.cs`)
- Setters `CPFCNPJ` migrados para usar `CpfCnpjValidator.SanitizeSeparators` + `CpfCnpjValidator.NormalizeAndValidate`.
- Avalista (`Boleto.Avalista` é instância de `Sacado`) recebe a mesma lógica transitivamente — sem código adicional.

### Test Support (`Boleto2.Net/Properties/AssemblyInfo.cs`)
- `[assembly: InternalsVisibleTo("Boleto2.Net.Testes")]` para permitir testar `Boleto2Net.Utils.FormataCPFCPPJ` (helper interno) diretamente sem expor publicamente.

### Tests — Setters (`Boleto2.Net.Testes/CnpjAlfanumericoSettersTests.cs`) — NEW
**28 testes** (vetor SERPRO oficial `AB12CD34EFGH83`):
- **Cedente flag ON** (10): aceita alfa válido, normaliza lowercase, trim whitespace, remove separadores, aceita CNPJ numérico, aceita CPF numérico, rejeita CPF com letras, rejeita CNPJ com caractere especial, rejeita DV com letras, rejeita length inválido.
- **Cedente flag OFF** (4): rejeita alfa, aceita CNPJ numérico, aceita CPF numérico, aceita CNPJ com máscara.
- **Sacado flag ON/OFF** (13): paridade completa com Cedente.
- **Avalista** (1): `Boleto { Avalista = new Sacado { CPFCNPJ = "AB12CD34EFGH83" } }` — fecha AC-7 do PRD (transitividade via tipo Sacado).

### Tests — Formatting (`Boleto2.Net.Testes/CnpjAlfanumericoFormattingTests.cs`) — NEW
**3 testes sanity** para `Boleto2Net.Utils.FormataCPFCPPJ` (helper position-based via `Substring`, sem mudanças):
- CPF numérico `"12345678901"` → `"123.456.789-01"` (regressão).
- CNPJ numérico `"12345678000195"` → `"12.345.678/0001-95"` (regressão).
- **CNPJ alfa `"AB12CD34EFGH83"` → `"AB.12C.D34/EFGH-83"`** (sanity confirma que helper position-based funciona com alfa out-of-the-box, sem reinterpretação numérica).

### Project files (`Boleto2.Net/Boleto2.Net.csproj`, `Boleto2.Net.Testes/Boleto2.Net.Testes.csproj`)
- Registro dos novos arquivos `CnabSettings.cs`, `CpfCnpjValidator.cs`, `CnpjAlfanumericoSettersTests.cs`, `CnpjAlfanumericoFormattingTests.cs` para serem incluídos no build.

## Como Testar

### 1. Build local
```bash
cd Boleto2.Net
msbuild Boleto2.Net.csproj /p:Configuration=Debug /t:Build
```
Esperado: zero erros (lib compila com .NET Framework 4.8).

### 2. Suite NUnit (CI AppVeyor)
A suite `Boleto2.Net.Testes` targeta .NET Framework 4.0 (limitação histórica da lib, ver TRD §7 do pre-dev). CI AppVeyor (image VS 2017) tem o SDK 4.0 e roda automaticamente. Total: **31 novos testes** + suite existente (regressão).

### 3. Validação manual de comportamento (opcional)

#### Flag OFF (default) — regressão
```csharp
// Comportamento esperado: idêntico ao pré-PR
var c1 = new Boleto2Net.Cedente { CPFCNPJ = "12345678000195" };           // OK → "12345678000195"
var c2 = new Boleto2Net.Cedente { CPFCNPJ = "12.345.678/0001-95" };       // OK → "12345678000195"
var c3 = new Boleto2Net.Cedente { CPFCNPJ = "AB12CD34EFGH83" };           // ArgumentException
```

#### Flag ON — novo comportamento
```csharp
Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = true;
try
{
    var c1 = new Boleto2Net.Cedente { CPFCNPJ = "AB12CD34EFGH83" };       // OK → "AB12CD34EFGH83"
    var c2 = new Boleto2Net.Cedente { CPFCNPJ = "ab12cd34efgh83" };       // OK → "AB12CD34EFGH83" (uppercase)
    var c3 = new Boleto2Net.Cedente { CPFCNPJ = "AB.12.CD3/4EFG-83" };    // OK → "AB12CD34EFGH83"
    var c4 = new Boleto2Net.Cedente { CPFCNPJ = "AB12CD34EFGHAB" };       // ArgumentException (DV deve ser numérico)
}
finally
{
    Boleto2Net.CnabSettings.SuportarCnpjAlfanumerico = false;
}
```

## Tarefas relacionadas

- **Jira:** [PAY-2324](https://kaminoonline.atlassian.net/browse/PAY-2324) — Boleto2Net (submódulo): Suporte a CNPJ alfanumérico
- **Épico:** [PAY-2096](https://kaminoonline.atlassian.net/browse/PAY-2096) — Suportar CNPJ Alfanumérico em toda a plataforma
- **Stories prerequisite (já em master do Hub-API):**
  - PAY-2097 — Funções centrais `Common.cs` + flag `ALPHANUMERIC_CNPJ_SUPPORT`
  - PAY-2098 — Persistência Pessoa + UDFs SQL
- **Story irmã (já em master do Hub-API):**
  - PAY-2100 — CNAB de pagamento + DP-Files + 4 callers banking (Cora/BS2/Stone/ICobranca)
- **PR2 (próximo passo após este mergear):**
  - Plataforma-Hub-API — bump submodule pointer + 4 swap sites em `Boleto.cs:557, 640, 734, 793` (`OnlyNumbers()` → `CleanCpfCnpj()`) + wiring `CnabSettings` no adapter + integration tests + ADR.

## Notas para o revisor

### Decisões arquiteturais (ver pre-dev TRD para detalhes)

1. **Estratégia B (CnabSettings static)** — alternativas avaliadas: A (permissivo sem flag) e C (parameter explícito). B preserva caminho OFF 100% bit-idêntico, alinha com regra Kamino "sem `lock`/sync primitives", testável ON/OFF nativamente via `[TearDown]`.

2. **Fork-only** — não tentar PR upstream (`BoletoNet/boleto2net` praticamente inativo: 1 commit em 2025, 0 issues sobre CNPJ alfa).

3. **Comportamento flag OFF mais estrito** — a implementação rejeita explicitamente conteúdo não-numérico com flag OFF (vs. comportamento legado que aceitava silenciosamente). Decisão consciente: testes do PRD/Gate 1 esperam essa rejeição (`Cedente_FlagOff_RejeitaAlfa`), e fail-loud em vez de fail-silent é defensivo. Pré-dev TRD §3.2 originalmente diz "OFF não valida conteúdo" mas tests divergem — segui os tests como source of truth, com efeito positivo.

4. **Helper interno DRY** (`CpfCnpjValidator`) — extraído para evitar duplicação entre setters Cedente e Sacado. `internal static`, sem exposição pública.

5. **Out-of-scope removido por YAGNI** — guard `NotSupportedException` em `ArquivoRemessa.GerarArquivoRemessa` originalmente planejado foi removido. Justificativa: flag não vai ser ligada em prod até FEBRABAN publicar spec CNAB 240 alfa (checklist de habilitação no `ADR-PAY-2097` do Hub-API), então o guard seria dead code preventivo. PRD AC-10 já tinha cláusula explícita *"se se mostrar viável; senão, fica documentado como follow-up"*.

### Compatibilidade

- **Consumers do submódulo Kamino**: `Plataforma-Hub-API` e família NFSe (`kamino-nfse`, `kamino-nfse-consumer`, `kamino-nfse-webhook-receiver`). Sanity grep (T1.9 do pre-dev) confirmou que NFSe não seta `Cedente.CPFCNPJ`/`Sacado.CPFCNPJ` com input alfa — sem regressão esperada.
- **Default flag OFF**: bit-idêntico ao pré-PR para input numérico. Mudança visível só em input com letras (aceito antes silenciosamente, agora rejeitado explicitamente — bug-catcher).
- **Consumers externos do fork** (improváveis): mesma compatibilidade — só impacta input com letras.

### Cobertura de testes

- **31 testes novos** em 2 fixtures.
- **Vetor SERPRO oficial** `AB12CD34EFGH83` (DV1=8, DV2=3) usado consistentemente — o mesmo validado em ADR-PAY-2097 do Hub-API.
- **Edge cases cobertos**: lowercase, whitespace, separadores, length inválido, DV não-numérico, caractere especial, CPF numérico flag ON/OFF, CNPJ numérico flag ON/OFF, CNPJ com máscara flag ON/OFF.
- **AC-7 (Avalista transitivo)** explicitamente coberto.

### Limitação de validação local conhecida

`Boleto2.Net.Testes.csproj` targeta .NET Framework 4.0 (mais antigo que a lib 4.8 — TRD §7), o que impede compilação local de testes em estação dev sem SDK 4.0 instalado. **CI AppVeyor (image VS 2017) tem o SDK e valida.** Lib `Boleto2.Net` compila localmente sem problemas.

### Histórico da branch

| Hash | Escopo |
|---|---|
| `0610893` | WIP intermediário — `CnabSettings.cs` + esqueleto de fixture (commit do início do desenvolvimento) |
| `a9a9b4c` | Setters Cedente/Sacado modificados + helper DRY `CpfCnpjValidator` + `InternalsVisibleTo` + `CnpjAlfanumericoFormattingTests.cs` |
| `1aa8e6a` | Expansão da fixture `CnpjAlfanumericoSettersTests.cs` para paridade Sacado vs Cedente + AC-7 (Avalista) — 11 testes adicionais |


[PAY-2324]: https://kamino.atlassian.net/browse/PAY-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ