### PR TITLE
fix(PAY-2324): restaura encoding Latin1 em Utils.cs (corrige RemoverAcentos)

### DIFF
--- a/Boleto2.Net/Util/Utils.cs
+++ b/Boleto2.Net/Util/Utils.cs
@@ -95,13 +95,13 @@ namespace Boleto2Net
             if (value.Trim().Length == 14)
                 return FormataCNPJ(value);
 
-            throw new Exception($"O CPF ou CNPJ: {value} ï¿½ invï¿½lido.");
+            throw new Exception($"O CPF ou CNPJ: {value} é inválido.");
         }
 
         /// <summary>
-        /// Formata o nï¿½mero do CPF 92074286520 para 920.742.865-20
+        /// Formata o número do CPF 92074286520 para 920.742.865-20
         /// </summary>
-        /// <param name="cpf">Sequencia numï¿½rica de 11 dï¿½gitos. Exemplo: 00000000000</param>
+        /// <param name="cpf">Sequencia numérica de 11 dígitos. Exemplo: 00000000000</param>
         /// <returns>CPF formatado</returns>
         internal static string FormataCPF(string cpf)
         {
@@ -118,7 +118,7 @@ namespace Boleto2Net
         /// <summary>
         /// Formata o CNPJ. Exemplo 00.316.449/0001-63
         /// </summary>
-        /// <param name="cnpj">Sequencia numï¿½rica de 14 dï¿½gitos. Exemplo: 00000000000000</param>
+        /// <param name="cnpj">Sequencia numérica de 14 dígitos. Exemplo: 00000000000000</param>
         /// <returns>CNPJ formatado</returns>
         internal static string FormataCNPJ(string cnpj)
         {
@@ -135,7 +135,7 @@ namespace Boleto2Net
         /// <summary>
         /// Formato o CEP em 00000-000
         /// </summary>
-        /// <param name="cep">Sequencia numï¿½rica de 8 dï¿½gitos. Exemplo: 00000000</param>
+        /// <param name="cep">Sequencia numérica de 8 dígitos. Exemplo: 00000000</param>
         /// <returns>CEP formatado</returns>
         internal static string FormataCEP(string cep)
         {
@@ -159,35 +159,35 @@ namespace Boleto2Net
         {
             try
             {
-                strline = strline.Replace("ï¿½", "a");
-                strline = strline.Replace('ï¿½', 'A');
-                strline = strline.Replace('ï¿½', 'a');
-                strline = strline.Replace('ï¿½', 'A');
-                strline = strline.Replace('ï¿½', 'a');
-                strline = strline.Replace('ï¿½', 'A');
-                strline = strline.Replace('ï¿½', 'a');
-                strline = strline.Replace('ï¿½', 'A');
-                strline = strline.Replace('ï¿½', 'c');
-                strline = strline.Replace('ï¿½', 'C');
-                strline = strline.Replace('ï¿½', 'e');
-                strline = strline.Replace('ï¿½', 'E');
-                strline = strline.Replace('ï¿½', 'E');
-                strline = strline.Replace('ï¿½', 'e');
-                strline = strline.Replace('ï¿½', 'o');
-                strline = strline.Replace('ï¿½', 'O');
-                strline = strline.Replace('ï¿½', 'o');
-                strline = strline.Replace('ï¿½', 'O');
-                strline = strline.Replace('ï¿½', 'o');
-                strline = strline.Replace('ï¿½', 'O');
-                strline = strline.Replace('ï¿½', 'u');
-                strline = strline.Replace('ï¿½', 'U');
-                strline = strline.Replace('ï¿½', 'u');
-                strline = strline.Replace('ï¿½', 'U');
-                strline = strline.Replace('ï¿½', 'i');
-                strline = strline.Replace('ï¿½', 'I');
-                strline = strline.Replace('ï¿½', 'a');
-                strline = strline.Replace('ï¿½', 'o');
-                strline = strline.Replace('ï¿½', 'o');
+                strline = strline.Replace("ã", "a");
+                strline = strline.Replace('Ã', 'A');
+                strline = strline.Replace('â', 'a');
+                strline = strline.Replace('Â', 'A');
+                strline = strline.Replace('á', 'a');
+                strline = strline.Replace('Á', 'A');
+                strline = strline.Replace('à', 'a');
+                strline = strline.Replace('À', 'A');
+                strline = strline.Replace('ç', 'c');
+                strline = strline.Replace('Ç', 'C');
+                strline = strline.Replace('é', 'e');
+                strline = strline.Replace('É', 'E');
+                strline = strline.Replace('Ê', 'E');
+                strline = strline.Replace('ê', 'e');
+                strline = strline.Replace('õ', 'o');
+                strline = strline.Replace('Õ', 'O');
+                strline = strline.Replace('ó', 'o');
+                strline = strline.Replace('Ó', 'O');
+                strline = strline.Replace('ô', 'o');
+                strline = strline.Replace('Ô', 'O');
+                strline = strline.Replace('ú', 'u');
+                strline = strline.Replace('Ú', 'U');
+                strline = strline.Replace('ü', 'u');
+                strline = strline.Replace('Ü', 'U');
+                strline = strline.Replace('í', 'i');
+                strline = strline.Replace('Í', 'I');
+                strline = strline.Replace('ª', 'a');
+                strline = strline.Replace('º', 'o');
+                strline = strline.Replace('°', 'o');
                 strline = strline.Replace('&', 'e');
                 return strline;
             }
@@ -259,7 +259,7 @@ namespace Boleto2Net
         }
 
         /// <summary>
-        /// Retorna uma string sem espaï¿½os no comeï¿½o ou fim e aceita campos nulos
+        /// Retorna uma string sem espaços no começo ou fim e aceita campos nulos
         /// </summary>
         /// <param name="text"></param>
         /// <returns></returns>


### PR DESCRIPTION
## Tipo da Alteração

- [x] Bug fix
- [ ] Feature
- [ ] Refactor

## Contexto

O PR #18 (CNPJ alfanumérico) corrompeu silenciosamente o encoding do arquivo `Boleto2.Net/Util/Utils.cs`. O arquivo original estava em **Latin1/Windows-1252**, mas foi re-salvo num editor configurado pra **UTF-8**, fazendo com que todos os caracteres acentuados (`á`, `à`, `â`, `ã`, `ç`, `é`, `ê`, `í`, `ó`, `ô`, `õ`, `ú`, etc.) virassem o **U+FFFD REPLACEMENT CHARACTER** (`\xef\xbf\xbd`).

## Impacto

O método `Utils.RemoverAcentos(string strline)` tem uma tabela de substituições do tipo `strline.Replace('á', 'a')` para 30+ caracteres acentuados. Com o encoding corrompido, **todos** os literais viraram `Replace('�', 'a')` — ou seja, o método agora só remove o char `�` (que não existe em nomes reais), preservando acentos no output.

**Sintoma observado**: ao gerar um CNAB FEBRABAN para uma Pessoa com nome contendo acento (`"Teste Unitário RecCNABTest"`), o output agora contém `TESTE UNITÁRIO` ao invés de `TESTE UNITARIO`. Bancos que esperam ASCII no layout 240/400 podem rejeitar a remessa.

**Detectado** pelo teste de integração `RecebimentoCnabItauTests.RecCnabHistoryTest` no Plataforma-Hub-API (kamino-company/Plataforma-Hub-API#7568 — bump do submódulo Boleto2Net).

## Diff de bytes (evidência)

| Versão | Bytes do Replace block |
|---|---|
| Pre-#18 (`3e3ebc8e`) | `Replace(\"\xe3\", \"a\")` (= `ã` Latin1), `Replace('\xc3', 'A')` (= `Ã`), etc. |
| Pós-#18 (`b24319cfc`) | `Replace(\"\xef\xbf\xbd\", \"a\")` (= U+FFFD), idem 30× |

## Solução

Restauradas as 70 linhas afetadas via:

```bash
git show 3e3ebc8e:Boleto2.Net/Util/Utils.cs > Boleto2.Net/Util/Utils.cs
```

Preservada a única mudança lógica do PR #18 neste arquivo: rename `FormataCPFCPPJ` → `FormataCPFCNPJ` (typo fix). As demais mudanças do PR #18 (novos arquivos `CnpjAlfanumericoFormattingTests.cs`, `CnpjAlfanumericoSettersTests.cs`, `CnabSettings.cs`, `CpfCnpjValidator.cs` e alterações em `Cedente.cs`/`Sacado.cs`) **estão intactas** — não foram tocadas por este PR.

## Regressão

Zero. Volta exatamente ao comportamento de `Utils.RemoverAcentos` pré-#18 que estava produção há anos.

## Plano de defesa contra recorrência (pós-merge)

Criar `.gitattributes` no repo com:

```
*.cs text working-tree-encoding=windows-1252
```

Garante que checkouts futuros normalizem o encoding nativo do projeto. Fica como follow-up porque foge do escopo deste fix.

## Referências

- PR consumidor: https://github.com/kamino-company/Plataforma-Hub-API/pull/7568
- CI quebrado: https://github.com/kamino-company/Plataforma-Hub-API/actions/runs/26171427183/job/76995522641
- Commit antigo válido: `3e3ebc8e48ad90ff13571e221675a4c4f7d51552`