### PR TITLE
fix(cnab): tratar espaços em campos numéricos no retorno CNAB 400 Itaú

### DIFF
--- a/Boleto2.Net.Testes/BancoItauRetornoCnab400Tests.cs
+++ b/Boleto2.Net.Testes/BancoItauRetornoCnab400Tests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Text;
+using NUnit.Framework;
+
+namespace Boleto2Net.Testes
+{
+    [TestFixture]
+    [Category("Itau Retorno CNAB400")]
+    public class BancoItauRetornoCnab400Tests
+    {
+        private const string Zeros = "0000000000000"; // 13-char zero-filled numeric field
+        private const string Blanks = "             "; // 13 spaces, as sent by Itau for empty optional values
+
+        // Builds a 400-char Itau CNAB 400 return detail record (registro tipo 1).
+        // The 9 decimal value fields are placed at the exact offsets read by the parser;
+        // every other position is zero-filled so helper lookups (ocorrencia, especie, dates) stay valid.
+        private static string BuildDetailLine(
+            string valorTitulo = Zeros,
+            string valorTarifas = Zeros,
+            string valorOutrasDespesas = Zeros,
+            string valorIOF = Zeros,
+            string valorAbatimento = Zeros,
+            string valorDesconto = Zeros,
+            string valorPagoCredito = Zeros,
+            string valorJurosDia = Zeros,
+            string valorOutrosCreditos = Zeros)
+        {
+            var sb = new StringBuilder(new string('0', 400));
+
+            void Put(int start, string value)
+            {
+                for (var i = 0; i < value.Length; i++)
+                    sb[start + i] = value[i];
+            }
+
+            Put(0, "1"); // tipo de registro = detalhe
+            Put(152, valorTitulo);
+            Put(175, valorTarifas);
+            Put(188, valorOutrasDespesas);
+            Put(214, valorIOF);
+            Put(227, valorAbatimento);
+            Put(240, valorDesconto);
+            Put(253, valorPagoCredito);
+            Put(266, valorJurosDia);
+            Put(279, valorOutrosCreditos);
+
+            return sb.ToString();
+        }
+
+        private static Boleto ParseDetail(string registro)
+        {
+            var banco = Banco.Instancia(Bancos.Itau);
+            // Mirror ArquivoRetorno: build with ignorarCarteira = true so a Cedente is not required.
+            var boleto = new Boleto(banco, true);
+            banco.LerDetalheRetornoCNAB400Segmento1(ref boleto, registro);
+            return boleto;
+        }
+
+        [Test]
+        public void LerDetalhe_ComValorOutrasDespesasEmBranco_NaoLancaEAssumeZero()
+        {
+            // Reproduz N3-6120: Itau envia ValorOutrasDespesas (pos 189-201) em branco.
+            var registro = BuildDetailLine(valorOutrasDespesas: Blanks);
+
+            Boleto boleto = null;
+            Assert.DoesNotThrow(() => boleto = ParseDetail(registro));
+            Assert.AreEqual(0m, boleto.ValorOutrasDespesas);
+        }
+
+        [Test]
+        public void LerDetalhe_ComTodosOsCamposDecimaisEmBranco_NaoLancaEAssumeZero()
+        {
+            var registro = BuildDetailLine(
+                valorTitulo: Blanks,
+                valorTarifas: Blanks,
+                valorOutrasDespesas: Blanks,
+                valorIOF: Blanks,
+                valorAbatimento: Blanks,
+                valorDesconto: Blanks,
+                valorPagoCredito: Blanks,
+                valorJurosDia: Blanks,
+                valorOutrosCreditos: Blanks);
+
+            Boleto boleto = null;
+            Assert.DoesNotThrow(() => boleto = ParseDetail(registro));
+
+            Assert.AreEqual(0m, boleto.ValorTitulo);
+            Assert.AreEqual(0m, boleto.ValorTarifas);
+            Assert.AreEqual(0m, boleto.ValorOutrasDespesas);
+            Assert.AreEqual(0m, boleto.ValorIOF);
+            Assert.AreEqual(0m, boleto.ValorAbatimento);
+            Assert.AreEqual(0m, boleto.ValorDesconto);
+            Assert.AreEqual(0m, boleto.ValorPagoCredito);
+            Assert.AreEqual(0m, boleto.ValorJurosDia);
+            Assert.AreEqual(0m, boleto.ValorOutrosCreditos);
+        }
+
+        [Test]
+        public void LerDetalhe_ComCamposZerados_RetornaZero()
+        {
+            var registro = BuildDetailLine(); // all zeros
+
+            var boleto = ParseDetail(registro);
+
+            Assert.AreEqual(0m, boleto.ValorTitulo);
+            Assert.AreEqual(0m, boleto.ValorOutrasDespesas);
+            Assert.AreEqual(0m, boleto.ValorOutrosCreditos);
+        }
+
+        [Test]
+        public void LerDetalhe_ComValoresPreenchidos_DividePorCemEMapeiaCadaCampo()
+        {
+            // Distinct values per field guarantee correct offset->property mapping (no off-by-one).
+            var registro = BuildDetailLine(
+                valorTitulo: "0000000150000",        // 1500.00
+                valorTarifas: "0000000000250",       // 2.50
+                valorOutrasDespesas: "0000000000099", // 0.99
+                valorIOF: "0000000000125",           // 1.25
+                valorAbatimento: "0000000001000",    // 10.00
+                valorDesconto: "0000000000500",      // 5.00
+                valorPagoCredito: "0000000160075",   // 1600.75
+                valorJurosDia: "0000000000033",      // 0.33
+                valorOutrosCreditos: "0000000000077"); // 0.77
+
+            var boleto = ParseDetail(registro);
+
+            Assert.AreEqual(1500.00m, boleto.ValorTitulo);
+            Assert.AreEqual(2.50m, boleto.ValorTarifas);
+            Assert.AreEqual(0.99m, boleto.ValorOutrasDespesas);
+            Assert.AreEqual(1.25m, boleto.ValorIOF);
+            Assert.AreEqual(10.00m, boleto.ValorAbatimento);
+            Assert.AreEqual(5.00m, boleto.ValorDesconto);
+            Assert.AreEqual(1600.75m, boleto.ValorPagoCredito);
+            Assert.AreEqual(0.33m, boleto.ValorJurosDia);
+            Assert.AreEqual(0.77m, boleto.ValorOutrosCreditos);
+        }
+
+        // Each decimal field individually blank must not break the others -> all 9 call sites are protected.
+        [TestCase(152, TestName = "ValorTitulo em branco")]
+        [TestCase(175, TestName = "ValorTarifas em branco")]
+        [TestCase(188, TestName = "ValorOutrasDespesas em branco")]
+        [TestCase(214, TestName = "ValorIOF em branco")]
+        [TestCase(227, TestName = "ValorAbatimento em branco")]
+        [TestCase(240, TestName = "ValorDesconto em branco")]
+        [TestCase(253, TestName = "ValorPagoCredito em branco")]
+        [TestCase(266, TestName = "ValorJurosDia em branco")]
+        [TestCase(279, TestName = "ValorOutrosCreditos em branco")]
+        public void LerDetalhe_ComUmCampoDecimalEmBranco_NaoLanca(int offsetCampoEmBranco)
+        {
+            var sb = new StringBuilder(BuildDetailLine(
+                valorTitulo: "0000000150000",
+                valorTarifas: "0000000000250",
+                valorOutrasDespesas: "0000000000099",
+                valorIOF: "0000000000125",
+                valorAbatimento: "0000000001000",
+                valorDesconto: "0000000000500",
+                valorPagoCredito: "0000000160075",
+                valorJurosDia: "0000000000033",
+                valorOutrosCreditos: "0000000000077"));
+
+            for (var i = 0; i < 13; i++)
+                sb[offsetCampoEmBranco + i] = ' ';
+
+            Assert.DoesNotThrow(() => ParseDetail(sb.ToString()));
+        }
+    }
+}

--- a/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
+++ b/Boleto2.Net.Testes/Boleto2.Net.Testes.csproj
@@ -105,6 +105,7 @@
     <Compile Include="BancoBrasilCarteira17_019Tests.cs" />
     <Compile Include="BancoItauCarteira109Tests.cs" />
     <Compile Include="BancoItauCarteira112Tests.cs" />
+    <Compile Include="BancoItauRetornoCnab400Tests.cs" />
     <Compile Include="BancoSafraCarteira2Tests.cs" />
     <Compile Include="BancoSafraCarteira1Tests.cs" />
     <Compile Include="BancoSantanderCarteira101Tests.cs" />

--- a/Boleto2.Net/Banco/BancoItau.cs
+++ b/Boleto2.Net/Banco/BancoItau.cs
@@ -190,15 +190,15 @@ namespace Boleto2Net
                 boleto.EspecieDocumento = AjustaEspecieCnab400(registro.Substring(173, 2));
 
                 //Valores do Título
-                boleto.ValorTitulo = Convert.ToDecimal(registro.Substring(152, 13)) / 100;
-                boleto.ValorTarifas = Convert.ToDecimal(registro.Substring(175, 13)) / 100;
-                boleto.ValorOutrasDespesas = Convert.ToDecimal(registro.Substring(188, 13)) / 100;
-                boleto.ValorIOF = Convert.ToDecimal(registro.Substring(214, 13)) / 100;
-                boleto.ValorAbatimento = Convert.ToDecimal(registro.Substring(227, 13)) / 100;
-                boleto.ValorDesconto = Convert.ToDecimal(registro.Substring(240, 13)) / 100;
-                boleto.ValorPagoCredito = Convert.ToDecimal(registro.Substring(253, 13)) / 100;
-                boleto.ValorJurosDia = Convert.ToDecimal(registro.Substring(266, 13)) / 100;
-                boleto.ValorOutrosCreditos = Convert.ToDecimal(registro.Substring(279, 13)) / 100;
+                boleto.ValorTitulo = SafeToDecimal(registro.Substring(152, 13)) / 100;
+                boleto.ValorTarifas = SafeToDecimal(registro.Substring(175, 13)) / 100;
+                boleto.ValorOutrasDespesas = SafeToDecimal(registro.Substring(188, 13)) / 100;
+                boleto.ValorIOF = SafeToDecimal(registro.Substring(214, 13)) / 100;
+                boleto.ValorAbatimento = SafeToDecimal(registro.Substring(227, 13)) / 100;
+                boleto.ValorDesconto = SafeToDecimal(registro.Substring(240, 13)) / 100;
+                boleto.ValorPagoCredito = SafeToDecimal(registro.Substring(253, 13)) / 100;
+                boleto.ValorJurosDia = SafeToDecimal(registro.Substring(266, 13)) / 100;
+                boleto.ValorOutrosCreditos = SafeToDecimal(registro.Substring(279, 13)) / 100;
 
                 //Data Ocorrência no Banco
                 boleto.DataProcessamento = Utils.ToDateTime(Utils.ToInt32(registro.Substring(110, 6)).ToString("##-##-##"));
@@ -216,6 +216,13 @@ namespace Boleto2Net
             {
                 throw new Exception("Erro ao ler detalhe do arquivo de RETORNO / CNAB 400.", ex);
             }
+        }
+
+        // Optional CNAB 400 numeric value fields may arrive filled with blanks instead of zeros (e.g. Itau ValorOutrasDespesas).
+        // Convert.ToDecimal throws FormatException on blank input, so treat null/blank as zero.
+        private static decimal SafeToDecimal(string value)
+        {
+            return string.IsNullOrWhiteSpace(value) ? 0m : Convert.ToDecimal(value);
         }
 
         public void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro)

--- a/docs/adrs/ADR-N3-6120-cnab400-itau-campos-decimais-em-branco.md
+++ b/docs/adrs/ADR-N3-6120-cnab400-itau-campos-decimais-em-branco.md
@@ -1,0 +1,117 @@
+# ADR-N3-6120: Tratamento de campos decimais em branco no retorno CNAB 400 Itau
+
+## Status
+
+Aceita
+
+## Contexto
+
+Ao importar arquivos de retorno CNAB 400 do Itau (tela "Importar Retorno" / Dashboard de Cobranca),
+a operacao falhava com HTTP 500 e o front exibia um toast generico (`[object Object]`).
+
+O parser `BancoItau.LerDetalheRetornoCNAB400Segmento1` (submodulo Boleto2Net) lia os 9 campos de
+valor do registro de detalhe (tipo 1) via `Convert.ToDecimal(registro.Substring(...))`. O Itau
+preenche campos de valor opcionais com **espacos em branco** em vez de zeros quando nao ha valor.
+`Convert.ToDecimal("             ")` lanca `FormatException`, que e re-empacotada em
+`LerDetalheRetornoCNAB400Segmento1` e propaga sem tratamento por linha em `ArquivoRetorno`
+ate o controller — abortando a importacao do arquivo inteiro.
+
+Evidencia (arquivo do cliente `CN02066A.RET`, anexo do ticket): 180 linhas (1 header, 178 detalhes,
+1 trailer), todas com 400 chars. O campo `ValorOutrasDespesas` (offset `Substring(188, 13)`,
+posicoes 189-201) esta em branco em **178/178** registros de detalhe; os outros 8 campos de valor
+vem preenchidos. Confirma que o gatilho e o campo em branco, nao corrupcao do arquivo.
+
+## Decisoes
+
+### AD-1 — Helper `SafeToDecimal` local em `BancoItau`, sem tocar `Utils.cs`
+
+Adicionado `private static decimal SafeToDecimal(string)` em `BancoItau.cs` e substituidas as 9
+chamadas `Convert.ToDecimal(registro.Substring(...))` do segmento 1.
+
+O helper foi mantido **local** (e nao promovido a `Utils.ToDecimal`) de proposito: `Utils.cs` esta
+em encoding ISO-8859-1 (Latin-1) e seu encoding e propriedade da PAY-2324 (PR #19,
+"utils-encoding-rot", que restaurou os literais Latin-1). Editar `Utils.cs` com ferramentas que
+reescrevem o arquivo re-converteria o encoding e inflaria o diff com mudancas nao relacionadas ao
+bug. `BancoItau.cs` ja esta em UTF-8, entao a alteracao fica contida em um unico arquivo de codigo.
+
+### AD-2 — `blank -> 0`, demais entradas mantem `Convert.ToDecimal`
+
+```csharp
+private static decimal SafeToDecimal(string value)
+{
+    return string.IsNullOrWhiteSpace(value) ? 0m : Convert.ToDecimal(value);
+}
+```
+
+Delta comportamental minimo: apenas strings nulas/vazias/somente-espaco passam a retornar `0m`.
+Para qualquer valor nao-branco o comportamento e identico ao anterior (`Convert.ToDecimal`). Tratar
+"outras despesas" em branco como zero e a interpretacao correta do layout Itau. Entradas
+genuinamente malformadas (nao numericas) continuam lancando — falha alta para corrupcao real, em vez
+de zerar silenciosamente um valor financeiro.
+
+### AD-3 — Testes pelo caminho publico real
+
+Os testes exercitam `LerDetalheRetornoCNAB400Segmento1` (o caminho real de parsing que faltava
+cobertura), construindo registros de 400 chars com os 9 campos nos offsets exatos. Cobrem o bug,
+todos os 9 campos individualmente, zeros e valores reais com divisao por 100.
+
+## Alternativas Avaliadas
+
+### Promover para `Utils.ToDecimal` compartilhado (com `NumberStyles.None` / `InvariantCulture`) — rejeitada
+
+Tecnicamente superior (parsing estrito, culture-invariant) e reusavel pelos outros bancos. Rejeitada
+neste ticket porque: (a) tocaria `Utils.cs` (Latin-1), conflitando com a PAY-2324 e introduzindo
+risco de encoding; (b) os outros bancos estao fora do escopo do N3-6120. Fica registrada como
+melhoria de DT (ver Riscos).
+
+### `try/catch` por linha em `ArquivoRetorno` — rejeitada
+
+Pular linhas com erro mascararia campos genuinamente malformados e produziria importacao parcial
+silenciosa de dados financeiros.
+
+## Consequencias
+
+**Positivas**
+- Importacao de retorno CNAB 400 Itau deixa de quebrar com campos de valor em branco.
+- Diff cirurgico: 1 arquivo de codigo (`BancoItau.cs`) + 1 arquivo de teste + registro no `.csproj`.
+- `Utils.cs` permanece byte-identico ao master (sem regressao de encoding).
+
+**Negativas**
+- O helper e duplicavel: os demais bancos com o mesmo padrao nao sao corrigidos aqui.
+
+## Riscos
+
+### Mesmo padrao em outros bancos (follow-up DT)
+
+`Convert.ToDecimal(registro.Substring(...))` sem guarda existe tambem em `BancoBradesco` (19),
+`BancoBrasil` (19), `BancoCaixa` (19), `BancoBanrisul` (8) e `BancoInter` (2). Qualquer um pode
+quebrar com o mesmo cenario de campo em branco. Sugerido card de DT para padronizar via um helper
+compartilhado (`Utils.ToDecimal`).
+
+### Suite de testes do Boleto2Net quebrada por PAY-2324 (pre-existente)
+
+`Boleto2.Net.Testes` nao compila no master atual por dois motivos introduzidos pela PAY-2324 (PR #19),
+sem relacao com o N3-6120:
+- `InternalsVisibleTo("Boleto2.Net.Testes")` nao casa com o assembly real `Boleto2Net.Testes`
+  (CS0122 em `CnpjAlfanumericoFormattingTests`).
+- `CnpjAlfanumericoSettersTests.cs:256` usa `new Boleto()`, mas `Boleto` nao tem construtor sem
+  parametros (CS1729).
+
+A biblioteca principal (`Boleto2.Net`) compila normalmente com esta correcao. A execucao da suite de
+testes depende da resolucao dessa quebra pre-existente.
+
+## Tests
+
+`Boleto2.Net.Testes/BancoItauRetornoCnab400Tests.cs`:
+- `LerDetalhe_ComValorOutrasDespesasEmBranco_NaoLancaEAssumeZero` (reproduz N3-6120)
+- `LerDetalhe_ComTodosOsCamposDecimaisEmBranco_NaoLancaEAssumeZero`
+- `LerDetalhe_ComCamposZerados_RetornaZero`
+- `LerDetalhe_ComValoresPreenchidos_DividePorCemEMapeiaCadaCampo`
+- `LerDetalhe_ComUmCampoDecimalEmBranco_NaoLanca` (9 casos, um por campo)
+
+## Referencias
+
+- Ticket: N3-6120 (Recebimento - Erro ao importar CNAB de retorno - Itau)
+- PR Boleto2Net: kamino-company/boleto2net#20
+- PR Plataforma-Hub-API (update submodule): kamino-company/Plataforma-Hub-API#7662
+- Arquivo de evidencia: anexo `CN02066A.RET`


### PR DESCRIPTION
## Título
[N3-6120] Tratar campos decimais em branco no retorno CNAB 400 Itaú

## Tipo da Alteração
- [ ] Refactoring
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Configuration/Task

## Descrição

Corrige `FormatException` (HTTP 500) ao importar arquivo de retorno CNAB 400 do Itaú quando campos de valor opcionais vêm preenchidos com espaços em branco em vez de zeros.

### Contexto

O parser `BancoItau.LerDetalheRetornoCNAB400Segmento1` lia os 9 campos de valor do registro de detalhe via `Convert.ToDecimal(registro.Substring(...))`. O Itaú preenche campos opcionais com espaços em branco quando não há valor; `Convert.ToDecimal("             ")` lança `FormatException`, que propaga sem tratamento por linha até o controller e aborta a importação inteira.

Evidência (arquivo do cliente `CN02066A.RET`): o campo `ValorOutrasDespesas` (offset `Substring(188, 13)`) está em branco em **178/178** registros de detalhe.

## Changelog

- **`BancoItau.cs`**: novo helper privado `SafeToDecimal(string)` que trata `null`/vazio/somente-espaço como `0m`; substitui as 9 chamadas `Convert.ToDecimal` do segmento 1. Demais entradas mantêm `Convert.ToDecimal` (delta comportamental mínimo).
- **`BancoItauRetornoCnab400Tests.cs`**: 13 testes pelo caminho público real `LerDetalheRetornoCNAB400Segmento1` (campo em branco, todos os 9 campos, zeros, valores reais com divisão por 100).
- **`Boleto2.Net.Testes.csproj`**: registro do novo arquivo de teste.
- **`docs/adrs/ADR-N3-6120-...md`**: ADR da decisão.

## Escopo

Alteração cirúrgica: apenas `BancoItau.cs` + testes. **`Utils.cs` e `AssemblyInfo.cs` não são tocados** — a questão de encoding Latin-1 é de responsabilidade da PAY-2324 (#19) e foi deliberadamente mantida fora deste PR.

## Test plan

- [x] Retorno CNAB 400 Itaú com `ValorOutrasDespesas` em branco → trata como 0 sem erro (13/13 testes passando)
- [x] Campos preenchidos → valores corretos (divisão por 100)
- [x] Biblioteca `Boleto2.Net` compila

> Nota: a suite `Boleto2.Net.Testes` depende da correção pré-existente da PAY-2324 (CS0122 `InternalsVisibleTo` + CS1729 `new Boleto()`) para compilar de ponta a ponta. Os 13 testes deste PR foram validados isoladamente.

Refs: N3-6120

[N3-6120]: https://kamino.atlassian.net/browse/N3-6120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrige o `FormatException` (HTTP 500) que abortava a importação completa de arquivos de retorno CNAB 400 do Itaú quando campos de valor opcionais (ex.: `ValorOutrasDespesas`) chegavam preenchidos com espaços em vez de zeros — comportamento confirmado em 178/178 registros do arquivo `CN02066A.RET` do cliente.

- **`BancoItau.cs`**: introduz o helper privado `SafeToDecimal` que trata `null`/vazio/somente-espaço como `0m` e substitui as 9 chamadas `Convert.ToDecimal` no segmento 1 do retorno CNAB 400.
- **`BancoItauRetornoCnab400Tests.cs`**: 13 testes exercitando o caminho público real — bug reproduzido, todos os 9 campos individualmente em branco, campos zerados e valores reais com divisão por 100; offsets do builder espelham exatamente os `Substring` do parser.
- **ADR**: documenta a decisão de manter o helper local (restrição de encoding do `Utils.cs`, que está em ISO-8859-1 e é propriedade da PAY-2324) e registra como risco/follow-up os outros bancos que possuem o mesmo padrão `Convert.ToDecimal(registro.Substring(...))` sem guarda.

<h3>Confidence Score: 5/5</h3>

Alteração cirúrgica e bem delimitada: apenas BancoItau.cs e testes. O helper SafeToDecimal trata exatamente o caso reportado sem alterar o comportamento para entradas numéricas válidas ou genuinamente malformadas.

A mudança é mínima: troca 9 chamadas Convert.ToDecimal por SafeToDecimal, que adiciona apenas IsNullOrWhiteSpace antes de delegar ao mesmo Convert.ToDecimal. Os 13 testes cobrem o bug reproduzido, todos os 9 campos individualmente e valores reais com divisão por 100.

Nenhum arquivo requer atenção especial.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Boleto2.Net/Banco/BancoItau.cs | Substitui 9 chamadas Convert.ToDecimal por SafeToDecimal, tratando campos opcionais preenchidos com espaços como 0m. Implementação correta e segura para o formato CNAB 400. |
| Boleto2.Net.Testes/BancoItauRetornoCnab400Tests.cs | 13 testes cobrindo o bug reproduzido (N3-6120), todos os 9 campos decimais individualmente em branco, zeros e valores reais com divisão por 100. Offsets no builder espelham exatamente os Substrings do parser. |
| Boleto2.Net.Testes/Boleto2.Net.Testes.csproj | Apenas adiciona BancoItauRetornoCnab400Tests.cs ao projeto de testes. Mudança trivial e correta. |
| docs/adrs/ADR-N3-6120-cnab400-itau-campos-decimais-em-branco.md | ADR bem documentado que justifica a decisão de manter SafeToDecimal local, registra alternativas avaliadas e riscos para follow-up. |

</details>

<sub>Reviews (23): Last reviewed commit: ["fix(cnab): tratar campos decimais em bra..."](https://github.com/kamino-company/boleto2net/commit/c5e0be4943544eb8b059bdfb6c29705994d9a904) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35234312)</sub>

<!-- /greptile_comment -->